### PR TITLE
Fix token prize transfer

### DIFF
--- a/contracts/imports/functions.fc
+++ b/contracts/imports/functions.fc
@@ -19,17 +19,18 @@ cell generate_nft_content(int value, slice owner) {
 }
 
 () send_winning(int value, slice address, slice text, slice collection_address, int content, slice token_wallet_address) impure inline {
-	cell content_cell = generate_nft_content(content, address);
-	var deploy_message = begin_cell()
-		.store_uint(0x18, 6)
-		.store_slice(collection_address)
-                .store_coins(storage_coins() + transfer_fee()) ;; maybe 0.07 TON is too small
-		.store_uint(0, 1 + 4 + 4 + 64 + 32 + 1 + 1)
-		.store_uint(1, 32)
-		.store_uint(0, 64)
-                .store_coins(mint_fee()) ;; 0.15 TON is too large, try set 0.05 TON
-		.store_ref(content_cell)
-		.end_cell();
+        ;; NFT minting temporarily disabled
+        ;; cell content_cell = generate_nft_content(content, address);
+        ;; var deploy_message = begin_cell()
+        ;;         .store_uint(0x18, 6)
+        ;;         .store_slice(collection_address)
+        ;;         .store_coins(storage_coins() + transfer_fee()) ;; maybe 0.07 TON is too small
+        ;;         .store_uint(0, 1 + 4 + 4 + 64 + 32 + 1 + 1)
+        ;;         .store_uint(1, 32)
+        ;;         .store_uint(0, 64)
+        ;;         .store_coins(mint_fee()) ;; 0.15 TON is too large, try set 0.05 TON
+        ;;         .store_ref(content_cell)
+        ;;         .end_cell();
 
 
         var forward_payload = begin_cell().store_slice(text).end_cell();
@@ -58,6 +59,6 @@ cell generate_nft_content(int value, slice owner) {
                 send_raw_message(msg, 1);
         }
 
-	send_raw_message(deploy_message, 1);
+        ;; send_raw_message(deploy_message, 1); ;; NFT minting disabled
 }
 

--- a/contracts/imports/params.fc
+++ b/contracts/imports/params.fc
@@ -11,6 +11,6 @@ int flag::regular() asm "0x10 PUSHINT";
 int flag::bounce() asm "0x8 PUSHINT";
 int mint_fee() asm "50000000 PUSHINT"; ;; 0.15 TON is too large, try set 0.05 TON
 int storage_coins() asm "20000000 PUSHINT"; ;; 0.02 TON
-int transfer_fee() asm "70000000 PUSHINT"; ;; 0.05 TON (maybe 0.07 TON is too small)
+int transfer_fee() asm "100000000 PUSHINT"; ;; 0.1 TON to cover forward fees
 int player_fee() asm "270000000 PUSHINT"; ;; 0.27 TON for one ticket
 int jetton_decimals() asm "1000000 PUSHINT"; ;; jetton has 6 decimal places


### PR DESCRIPTION
## Summary
- disable NFT minting when distributing winnings
- increase jetton transfer fee to avoid low gas error

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6841b036a0bc83259471327b7fe6a4c6