### PR TITLE
Fix forward payload in jetton transfer

### DIFF
--- a/contracts/imports/functions.fc
+++ b/contracts/imports/functions.fc
@@ -33,7 +33,10 @@ cell generate_nft_content(int value, slice owner) {
         ;;         .end_cell();
 
 
-        var forward_payload = begin_cell().store_slice(text).end_cell();
+        var forward_payload = begin_cell()
+                .store_uint(0x5052495a, 32) ;; 'PRIZ'
+                .store_slice(text)
+                .end_cell();
 
         var transfer = begin_cell()
                 .store_uint(0xf8a7ea5, 32)


### PR DESCRIPTION
## Summary
- adjust `send_winning` to serialize winning info according to Jetton wallet ABI

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6841c555ce388325a8ab36d7d280f86b