### PR TITLE
Add jetton wallet helper and extend Jet test

### DIFF
--- a/tests/Jet.spec.ts
+++ b/tests/Jet.spec.ts
@@ -1,6 +1,8 @@
 import { Blockchain, SandboxContract, TreasuryContract } from '@ton/sandbox';
-import { Address, beginCell, Cell, fromNano, internal, toNano } from '@ton/core';
+import { Address, beginCell, Cell, toNano, internal } from '@ton/core';
 import { Jet } from '../wrappers/Jet';
+import { JettonMaster } from '../wrappers/JettonMaster';
+import { JettonWallet } from '../wrappers/JettonWallet';
 import '@ton/test-utils';
 import { compile } from '@ton/blueprint';
 
@@ -14,12 +16,81 @@ describe('Jet', () => {
     let blockchain: Blockchain;
     let deployer: SandboxContract<TreasuryContract>;
     let jet: SandboxContract<Jet>;
+    let jettonMaster: SandboxContract<JettonMaster>;
 
     beforeEach(async () => {
         blockchain = await Blockchain.create();
 
         deployer = await blockchain.treasury('deployer');
+
+        jettonMaster = blockchain.openContract(
+            JettonMaster.createFromConfig(
+                {
+                    admin: deployer.address,
+                    content: beginCell().endCell(),
+                    symbol: 'USDT',
+                    decimals: 6,
+                },
+                beginCell().endCell(),
+            ),
+        );
+
+        await jettonMaster.sendDeploy(deployer.getSender(), toNano('0.05'));
+
+        const wallet = await blockchain.treasury('lottery-wallet');
+
+        jet = blockchain.openContract(
+            Jet.createFromConfig(
+                {
+                    collectionAddress: deployer.address,
+                    adminAddress: deployer.address.toString(),
+                    price: 10n * 1_000_000n,
+                    refPercent: 0,
+                    tokenAddress: wallet.address,
+                },
+                code,
+            ),
+        );
+
+        await jet.sendDeploy(deployer.getSender(), toNano('0.05'));
+        await jet.sendSetTokenWalletAddress(deployer.getSender(), wallet.address, toNano('0.01'));
+
+        await jettonMaster.mint(deployer.getSender(), wallet.address, 1_000_000_000n);
     });
 
-    it('should deploy', async () => {});
+    it('should send winnings', async () => {
+        const player = await blockchain.treasury('player');
+        const playerWallet = blockchain.openContract(
+            JettonWallet.createFromAddress(Address.parseRaw(player.address.toString())),
+        );
+
+        const forwardPayload = beginCell()
+            .storeUint(0x5052495a, 32)
+            .storeUint(6, 8)
+            .endCell();
+
+        const body = beginCell()
+            .storeUint(0x7362d09c, 32)
+            .storeUint(0, 64)
+            .storeCoins(10n * 1_000_000n)
+            .storeAddress(player.address)
+            .storeUint(1, 1)
+            .storeRef(forwardPayload)
+            .endCell();
+
+        const result = await blockchain.sendMessage(
+            internal({
+                from: player.address,
+                to: jet.address,
+                value: toNano('0.3'),
+                bounce: true,
+                body,
+            }),
+        );
+
+        expect(result.transactions).toHaveTransaction({
+            from: jet.address,
+            success: true,
+        });
+    });
 });

--- a/wrappers/JettonWallet.ts
+++ b/wrappers/JettonWallet.ts
@@ -1,0 +1,40 @@
+import { Address, beginCell, Cell, Contract, ContractProvider, Sender, SendMode } from '@ton/core';
+
+export class JettonWallet implements Contract {
+    constructor(readonly address: Address, readonly init?: { code: Cell; data: Cell }) {}
+
+    static createFromAddress(address: Address) {
+        return new JettonWallet(address);
+    }
+
+    async sendTransfer(
+        provider: ContractProvider,
+        via: Sender,
+        args: {
+            amount: bigint;
+            destination: Address;
+            responseAddress: Address;
+            forwardAmount: bigint;
+            forwardPayload?: Cell;
+        },
+    ) {
+        const body = beginCell()
+            .storeUint(0xf8a7ea5, 32)
+            .storeUint(0, 64)
+            .storeCoins(args.amount)
+            .storeAddress(args.destination)
+            .storeAddress(args.responseAddress)
+            .storeBit(0) // no custom payload
+            .storeCoins(args.forwardAmount);
+        if (args.forwardPayload) {
+            body.storeUint(1, 1).storeRef(args.forwardPayload);
+        } else {
+            body.storeUint(0, 1);
+        }
+        await provider.internal(via, {
+            value: args.forwardAmount + 1n, // minimal value just to cover fees
+            sendMode: SendMode.PAY_GAS_SEPARATELY,
+            body: body.endCell(),
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- add `JettonWallet` wrapper for sending jetton transfers
- deploy a stub jetton master and lottery in `Jet.spec.ts`
- send a mocked ticket purchase and expect successful prize payout

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6841dddca9bc8325b1dd5d15b56dd472