### PR TITLE
Fix jetton test wrapper

### DIFF
--- a/tests/Jet.spec.ts
+++ b/tests/Jet.spec.ts
@@ -55,7 +55,7 @@ describe('Jet', () => {
         await jet.sendDeploy(deployer.getSender(), toNano('0.05'));
         await jet.sendSetTokenWalletAddress(deployer.getSender(), wallet.address, toNano('0.01'));
 
-        await jettonMaster.mint(deployer.getSender(), wallet.address, 1_000_000_000n);
+        await jettonMaster.sendMint(deployer.getSender(), wallet.address, 1_000_000_000n);
     });
 
     it('should send winnings', async () => {
@@ -64,29 +64,15 @@ describe('Jet', () => {
             JettonWallet.createFromAddress(Address.parseRaw(player.address.toString())),
         );
 
-        const forwardPayload = beginCell()
-            .storeUint(0x5052495a, 32)
-            .storeUint(6, 8)
-            .endCell();
+        const forwardPayload = beginCell().storeUint(0x5052495a, 32).storeUint(6, 8).endCell();
 
-        const body = beginCell()
-            .storeUint(0x7362d09c, 32)
-            .storeUint(0, 64)
-            .storeCoins(10n * 1_000_000n)
-            .storeAddress(player.address)
-            .storeUint(1, 1)
-            .storeRef(forwardPayload)
-            .endCell();
-
-        const result = await blockchain.sendMessage(
-            internal({
-                from: player.address,
-                to: jet.address,
-                value: toNano('0.3'),
-                bounce: true,
-                body,
-            }),
-        );
+        const result = await playerWallet.sendTransfer(player.getSender(), {
+            amount: 10n * 1_000_000n,
+            destination: jet.address,
+            responseAddress: player.address,
+            forwardAmount: toNano('0.3'),
+            forwardPayload,
+        });
 
         expect(result.transactions).toHaveTransaction({
             from: jet.address,

--- a/wrappers/JettonMaster.ts
+++ b/wrappers/JettonMaster.ts
@@ -3,35 +3,26 @@
  *  и тестов USDT-Jetton’ом.
  * ------------------------------------------------------------------------*/
 
-import {
-    Address,
-    Cell,
-    Contract,
-    contractAddress,
-    ContractProvider,
-    Sender,
-    SendMode,
-    beginCell,
-} from '@ton/core';
+import { Address, Cell, Contract, contractAddress, ContractProvider, Sender, SendMode, beginCell } from '@ton/core';
 
 /* ------------------------------------------------------------------ */
 /*  CONFIG  → init-data (нужно только для sandbox-тестов)            */
 /* ------------------------------------------------------------------ */
 export type JettonMasterConfig = {
-    admin: Address;   // владелец мастера / минтер
-    content: Cell;    // off-chain контент (IPFS/JSON)
-    symbol: string;   // «USDT»
+    admin: Address; // владелец мастера / минтер
+    content: Cell; // off-chain контент (IPFS/JSON)
+    symbol: string; // «USDT»
     decimals: number; // 6
 };
 
 export function jettonMasterConfigToCell(cfg: JettonMasterConfig): Cell {
     return beginCell()
-        .storeUint(0, 2)                 // пустая опция (00)
+        .storeUint(0, 2) // пустая опция (00)
         .storeAddress(cfg.admin)
         .storeRef(cfg.content)
         .storeUint(cfg.decimals, 8)
         .storeStringRefTail(cfg.symbol)
-    .endCell();
+        .endCell();
 }
 
 /* ------------------------------------------------------------------ */
@@ -49,22 +40,14 @@ export class JettonMaster implements Contract {
     }
 
     /* сформировать init-структуру (sandbox) */
-    static createFromConfig(
-        cfg: JettonMasterConfig,
-        code: Cell,
-        workchain = 0,
-    ) {
+    static createFromConfig(cfg: JettonMasterConfig, code: Cell, workchain = 0) {
         const data = jettonMasterConfigToCell(cfg);
         const init = { code, data };
         return new JettonMaster(contractAddress(workchain, init), init);
     }
 
     /* -----------------  DEPLOY  (для тестовой среды)  -------------- */
-    async sendDeploy(
-        provider: ContractProvider,
-        via: Sender,
-        value: bigint,
-    ) {
+    async sendDeploy(provider: ContractProvider, via: Sender, value: bigint) {
         await provider.internal(via, {
             value,
             sendMode: SendMode.PAY_GAS_SEPARATELY,
@@ -73,49 +56,36 @@ export class JettonMaster implements Contract {
     }
 
     /* ---------------  TIP-3.1 get_wallet_address()  ---------------- */
-    async getWalletAddress(
-        provider: ContractProvider,
-        owner: Address,
-    ): Promise<Address> {
+    async getWalletAddress(provider: ContractProvider, owner: Address): Promise<Address> {
         const res = await provider.get('get_wallet_address', [
             { type: 'slice', cell: beginCell().storeAddress(owner).endCell() },
         ]);
         return res.stack.readAddress();
     }
 
-    async sendDeployWallet(
-        provider: ContractProvider,
-        via: Sender,
-        owner: Address,
-        value: bigint,
-    ) {
-        const body = beginCell()
-            .storeUint(0x0c0d5934, 32)
-            .storeUint(0, 64)
-            .storeAddress(owner)
-            .endCell();
+    async sendDeployWallet(provider: ContractProvider, via: Sender, owner: Address, value: bigint) {
+        const body = beginCell().storeUint(0x0c0d5934, 32).storeUint(0, 64).storeAddress(owner).endCell();
         await provider.internal(via, { value, body });
     }
 
     /* ---------------- MINT (для e2e-тестов) ------------------------ */
-async mint(
-    provider: ContractProvider,
-    via: Sender,
-    walletAddr: Address,
-    amount: bigint,
-) {
-    const body = beginCell()
-        .storeUint(21, 32)        // op-код mint (произвольный)
-        .storeUint(0, 64)
-        .storeAddress(walletAddr)
-        .storeUint(amount, 128)
-    .endCell();
+    async mint(provider: ContractProvider, via: Sender, walletAddr: Address, amount: bigint) {
+        const body = beginCell()
+            .storeUint(21, 32) // op-код mint (произвольный)
+            .storeUint(0, 64)
+            .storeAddress(walletAddr)
+            .storeUint(amount, 128)
+            .endCell();
 
-    await provider.internal(via, {
-        value: 100_000_000n,      // 0.1 TON  (bigint!)
-        sendMode: SendMode.PAY_GAS_SEPARATELY,
-        body,
-    });
-}
+        await provider.internal(via, {
+            value: 100_000_000n, // 0.1 TON  (bigint!)
+            sendMode: SendMode.PAY_GAS_SEPARATELY,
+            body,
+        });
+    }
 
+    // Helper with "send" prefix for SandboxContract compatibility
+    async sendMint(provider: ContractProvider, via: Sender, walletAddr: Address, amount: bigint) {
+        await this.mint(provider, via, walletAddr, amount);
+    }
 }


### PR DESCRIPTION
## Summary
- add `sendMint` helper to `JettonMaster` for compatibility with `SandboxContract`
- update Jet tests to use `sendMint` and send jettons via `JettonWallet`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6841e3cee7948325ba91bad60c54e3bf