### PR TITLE
Fix Jet test by deploying jetton wallets

### DIFF
--- a/tests/Jet.spec.ts
+++ b/tests/Jet.spec.ts
@@ -37,8 +37,6 @@ describe('Jet', () => {
 
         await jettonMaster.sendDeploy(deployer.getSender(), toNano('0.05'));
 
-        const wallet = await blockchain.treasury('lottery-wallet');
-
         jet = blockchain.openContract(
             Jet.createFromConfig(
                 {
@@ -46,22 +44,28 @@ describe('Jet', () => {
                     adminAddress: deployer.address.toString(),
                     price: 10n * 1_000_000n,
                     refPercent: 0,
-                    tokenAddress: wallet.address,
+                    tokenAddress: deployer.address, // will be replaced after deploy
                 },
                 code,
             ),
         );
 
         await jet.sendDeploy(deployer.getSender(), toNano('0.05'));
-        await jet.sendSetTokenWalletAddress(deployer.getSender(), wallet.address, toNano('0.01'));
 
-        await jettonMaster.sendMint(deployer.getSender(), wallet.address, 1_000_000_000n);
+        const jetWalletAddress = await jettonMaster.getWalletAddress(jet.address);
+        await jettonMaster.sendDeployWallet(deployer.getSender(), jet.address, toNano('0.05'));
+        await jet.sendSetTokenWalletAddress(deployer.getSender(), jetWalletAddress, toNano('0.01'));
+
+        await jettonMaster.sendMint(deployer.getSender(), jetWalletAddress, 1_000_000_000n);
     });
 
     it('should send winnings', async () => {
         const player = await blockchain.treasury('player');
+        const playerWalletAddress = await jettonMaster.getWalletAddress(player.address);
+        await jettonMaster.sendDeployWallet(deployer.getSender(), player.address, toNano('0.05'));
+        await jettonMaster.sendMint(deployer.getSender(), playerWalletAddress, 20n * 1_000_000n);
         const playerWallet = blockchain.openContract(
-            JettonWallet.createFromAddress(Address.parse(player.address.toString())),
+            JettonWallet.createFromAddress(playerWalletAddress),
         );
 
         const forwardPayload = beginCell().storeUint(0x5052495a, 32).storeUint(6, 8).endCell();


### PR DESCRIPTION
## Summary
- ensure Jet has its own jetton wallet deployed
- deploy and mint a jetton wallet for the player before transferring

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6841f11ff1d88325b22ca915b719aab5