### PR TITLE
Fix Jet test by deploying jetton wallets

### DIFF
--- a/tests/Jet.spec.ts
+++ b/tests/Jet.spec.ts
@@ -17,6 +17,7 @@ describe('Jet', () => {
     let deployer: SandboxContract<TreasuryContract>;
     let jet: SandboxContract<Jet>;
     let jettonMaster: SandboxContract<JettonMaster>;
+    let jetWalletAddress: Address;
 
     beforeEach(async () => {
         blockchain = await Blockchain.create();
@@ -37,8 +38,6 @@ describe('Jet', () => {
 
         await jettonMaster.sendDeploy(deployer.getSender(), toNano('0.05'));
 
-        const wallet = await blockchain.treasury('lottery-wallet');
-
         jet = blockchain.openContract(
             Jet.createFromConfig(
                 {
@@ -46,22 +45,28 @@ describe('Jet', () => {
                     adminAddress: deployer.address.toString(),
                     price: 10n * 1_000_000n,
                     refPercent: 0,
-                    tokenAddress: wallet.address,
+                    tokenAddress: deployer.address, // will be replaced after deploy
                 },
                 code,
             ),
         );
 
         await jet.sendDeploy(deployer.getSender(), toNano('0.05'));
-        await jet.sendSetTokenWalletAddress(deployer.getSender(), wallet.address, toNano('0.01'));
 
-        await jettonMaster.sendMint(deployer.getSender(), wallet.address, 1_000_000_000n);
+        jetWalletAddress = await jettonMaster.getWalletAddress(jet.address);
+        await jettonMaster.sendDeployWallet(deployer.getSender(), jet.address, toNano('0.05'));
+        await jet.sendSetTokenWalletAddress(deployer.getSender(), jetWalletAddress, toNano('0.01'));
+
+        await jettonMaster.sendMint(deployer.getSender(), jetWalletAddress, 1_000_000_000n);
     });
 
     it('should send winnings', async () => {
         const player = await blockchain.treasury('player');
+        const playerWalletAddress = await jettonMaster.getWalletAddress(player.address);
+        await jettonMaster.sendDeployWallet(deployer.getSender(), player.address, toNano('0.05'));
+        await jettonMaster.sendMint(deployer.getSender(), playerWalletAddress, 20n * 1_000_000n);
         const playerWallet = blockchain.openContract(
-            JettonWallet.createFromAddress(Address.parse(player.address.toString())),
+            JettonWallet.createFromAddress(playerWalletAddress),
         );
 
         const forwardPayload = beginCell().storeUint(0x5052495a, 32).storeUint(6, 8).endCell();
@@ -75,7 +80,8 @@ describe('Jet', () => {
         });
 
         expect(result.transactions).toHaveTransaction({
-            from: jet.address,
+            from: jetWalletAddress,
+            to: playerWalletAddress,
             success: true,
         });
     });


### PR DESCRIPTION
## Summary
- ensure Jet has its own jetton wallet deployed
- deploy and mint a jetton wallet for the player before transferring
- check that Jet wallet sends winnings back to the player wallet

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6841f11ff1d88325b22ca915b719aab5