### PR TITLE
Fix duplicate expect in Jet test

### DIFF
--- a/tests/Jet.spec.ts
+++ b/tests/Jet.spec.ts
@@ -230,7 +230,5 @@ describe('Jet', () => {
                 .some((msg) => msg?.info?.dest?.toString() === playerWalletAddress.toString())
         );
         expect(txToPlayer).toBeUndefined();
-
-        expect(txToPlayer).toBeUndefined();
     });
 });


### PR DESCRIPTION
## Summary
- remove redundant assertion from Jet.spec.ts

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_68420b951a688325a8a7bf0b5a54aeb4