### PR TITLE
Simplify Jet lottery

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,17 +5,12 @@
 ## Установка
 1. `npm install`
 2. Скопируйте `.env.example` в `.env` и заполните параметры:
-   - `COLLECTION_OWNER` – владелец NFT‑коллекции;
    - `ADMIN_ADDRESS` – кошелёк администратора лотереи;
    - `TOKEN_ADDRESS` – jetton, используемый для оплаты билетов;
    - `TICKET_PRICE` – стоимость билета в jetton;
-   - `REF_PERCENT` – процент для реферала (в б.п.).
 
 ## Деплой
-1. Подготовьте метаданные `collection.json` и `0.json–7.json`, загрузите их в IPFS и укажите ссылку в `collectionConfig.content`.
-2. Запустите `npm run start` и выберите `deployCollection` – будет создан контракт коллекции NFT.
-3. Настройте `lotteryConfig` в `scripts/deployJet.ts` и выберите `deployJet` для развертывания лотереи.
-4. Выполните `setLotteryAddress()` из того же скрипта, чтобы лотерея могла минтить NFT.
+1. Настройте `lotteryConfig` в `scripts/deployJet.ts` и выберите `deployJet` для развертывания лотереи.
 
 В `deployJet.ts` также доступны функции `withdraw()` и `finishRound(winner)`.
 
@@ -24,31 +19,24 @@
 
 ## Механика лотереи
 1. После получения платежа генерируется случайное число `x` от 0 до 11999.
-2. При `x == 0` контракт уведомляет администратора о потенциальном джекпоте. Админ вызывает `finishRound(address)`:
-   - игрок получает `JACKPOT_PRIZE` (10 000 jetton) и NFT `0`;
-   - счётчик джекпота увеличивается и новые билеты не принимаются.
+2. При `x == 0` контракт уведомляет администратора о потенциальном джекпоте. Админ вызывает `finishRound(address)` и игрок получает `JACKPOT_PRIZE` (10 000 jetton).
 3. Иначе сравниваются диапазоны и лимиты выигрышей:
-   - `x < 4` и `major < 3` – **Major** (1 800 jetton, NFT `1`)
-   - `x < 14` и `high < 10` – **High** (700 jetton, NFT `2`)
-   - `x < 64` и `mid < 50` – **Mid** (180 jetton, NFT `3`)
-   - `x < 214` и `low_mid < 150` – **Low Mid** (50 jetton, NFT `4`)
-   - `x < 514` и `low < 300` – **Low** (25 jetton, NFT `5`)
-   - `x < 1714` и `mini < 1200` – **Mini** (10 jetton, NFT `6`)
-   - иначе игрок получает NFT `7` без приза.
-4. После выдачи призов соответствующие счётчики увеличиваются, NFT минтится из коллекции, а jetton переводится игроку.
+   - `x < 4` и `major < 3` – **Major** (1 800 jetton)
+   - `x < 14` и `high < 10` – **High** (700 jetton)
+   - `x < 64` и `mid < 50` – **Mid** (180 jetton)
+   - `x < 214` и `low_mid < 150` – **Low Mid** (50 jetton)
+   - `x < 514` и `low < 300` – **Low** (25 jetton)
+   - `x < 1714` и `mini < 1200` – **Mini** (10 jetton)
+   - иначе игрок остаётся без приза.
+4. После выдачи призов соответствующие счётчики увеличиваются, а jetton переводится игроку.
 5. На контракте должно оставаться не менее 0.05 TON и достаточный запас jetton для будущих выплат.
-6. При отправке билета в `forward_payload` первым помещайте свой TON‑кошелёк, а после него при желании адрес реферала. В поле `forward_ton_amount` укажите не менее `0.27` TON.
+6. При отправке билета в `forward_payload` помещайте свой TON‑кошелёк. В поле `forward_ton_amount` укажите не менее `0.27` TON.
 
 ## Пример отправки билета
 ```tsx
 import { beginCell, Address } from '@ton/core';
 
-const referral = undefined as string | undefined;
-
 const forwardPayloadBuilder = beginCell().storeAddress(userWallet); // player wallet
-if (referral) {
-  forwardPayloadBuilder.storeAddress(Address.parse(referral));
-}
 const forwardPayload = forwardPayloadBuilder.endCell();
 
 const payload = beginCell()

--- a/contracts/imports/functions.fc
+++ b/contracts/imports/functions.fc
@@ -19,19 +19,7 @@ cell generate_nft_content(int value, slice owner) {
     return begin_cell().store_slice(owner).store_ref(result.store_slice(".json").end_cell()).end_cell();
 }
 
-() send_winning(int value, slice address, int prize_code, slice collection_address, int content, slice token_wallet_address) impure inline {
-        ;; NFT minting temporarily disabled
-        ;; cell content_cell = generate_nft_content(content, address);
-        ;; var deploy_message = begin_cell()
-        ;;         .store_uint(0x18, 6)
-        ;;         .store_slice(collection_address)
-        ;;         .store_coins(storage_coins() + transfer_fee()) ;; maybe 0.07 TON is too small
-        ;;         .store_uint(0, 1 + 4 + 4 + 64 + 32 + 1 + 1)
-        ;;         .store_uint(1, 32)
-        ;;         .store_uint(0, 64)
-        ;;         .store_coins(mint_fee()) ;; 0.15 TON is too large, try set 0.05 TON
-        ;;         .store_ref(content_cell)
-        ;;         .end_cell();
+() send_winning(int value, slice address, int prize_code, slice token_wallet_address) impure inline {
 
 
         var forward_payload = begin_cell()
@@ -45,9 +33,9 @@ cell generate_nft_content(int value, slice owner) {
                 .store_coins(value * jetton_decimals())
                 .store_slice(address)
                 .store_slice(my_address())
-                .store_maybe_ref(null())
+                .store_uint(0, 1)
                 .store_coins(transfer_fee())
-                .store_uint(1, 1) ;; store reference indicator for Either
+                .store_uint(1, 1)
                 .store_ref(forward_payload)
                 .end_cell();
 
@@ -62,7 +50,5 @@ cell generate_nft_content(int value, slice owner) {
         if (value != 0) {
                 send_raw_message(msg, 1);
         }
-
-        ;; send_raw_message(deploy_message, 1); ;; NFT minting disabled
 }
 

--- a/contracts/jet.fc
+++ b/contracts/jet.fc
@@ -13,10 +13,8 @@ int MINI_PRIZE() asm "10 PUSHINT";       ;; 10 tokens
 (
     cell, ;; counters
     int, ;; next_ticket_index
-    slice, ;; collection_address
     slice, ;; owner address
     int, ;; ticket_price (jettons)
-    int, ;; ref_percent
     slice ;; token_wallet_address
 ) load_data() inline {
     var ds = get_data().begin_parse();
@@ -24,9 +22,7 @@ int MINI_PRIZE() asm "10 PUSHINT";       ;; 10 tokens
         ds~load_ref(),
         ds~load_uint(64),
         ds~load_msg_addr(),
-        ds~load_msg_addr(),
         ds~load_uint(128), ;; ticket_price in jettons
-        ds~load_uint(16),
         ds~load_msg_addr()
     );
 }
@@ -34,20 +30,16 @@ int MINI_PRIZE() asm "10 PUSHINT";       ;; 10 tokens
 () store_data(
 cell counters_ref,
 int next_ticket_index,
-slice collection_address,
 slice admin_address,
 int price,
-int ref_percent,
 slice token_wallet_address
 ) impure inline {
     set_data(
         begin_cell()
             .store_ref(counters_ref)
             .store_uint(next_ticket_index, 64)
-            .store_slice(collection_address)
             .store_slice(admin_address)
             .store_uint(price, 128)
-            .store_uint(ref_percent, 16)
             .store_slice(token_wallet_address)
             .end_cell()
     );
@@ -67,10 +59,8 @@ slice token_wallet_address
     var (
         cell counters_ref,
         int next_ticket_index,
-        slice collection_address,
         slice admin_address,
         int price,
-        int ref_percent,
         slice token_wallet_address
     ) = load_data();
 
@@ -118,61 +108,21 @@ slice token_wallet_address
         }
 
         slice player_address = sender_wallet;
-        slice ref_addr = null_addr();
-        int has_ref = 0;
 
         int prize_code = -1;
         int has_prize = 0;
 
         int bits = slice_bits(fwd_payload);
 
-        ;; full format: player + referral address
-        if (bits >= 534) {
+        if (bits >= 267) {
             player_address = fwd_payload~load_msg_addr();
-            ref_addr = fwd_payload~load_msg_addr();
-            has_ref = 1;
-        }
-        ;; ref format: only referral address
-        else {
-            if (bits >= 267) {
-                ref_addr = fwd_payload~load_msg_addr();
-                has_ref = 1;
-            }
-            ;; label format: uint32 op_code + uint8 prize_code
-            else {
-                if (bits >= 40) {
-                    int op_code = fwd_payload~load_uint(32);
-                    if (op_code == op::send_prize()) {
-                        prize_code = fwd_payload~load_uint(8);
-                        has_prize = 1;
-                    }
+        } else {
+            if (bits >= 40) {
+                int op_code = fwd_payload~load_uint(32);
+                if (op_code == op::send_prize()) {
+                    prize_code = fwd_payload~load_uint(8);
+                    has_prize = 1;
                 }
-            }
-        }
-
-
-        if (has_ref) {
-            int referral_amount = (price * ref_percent) / 100;
-            if (referral_amount > 0) {
-                var ref_transfer = begin_cell()
-                    .store_uint(0xf8a7ea5, 32)
-                    .store_uint(0, 64)
-                    .store_coins(referral_amount)
-                    .store_slice(ref_addr)
-                    .store_slice(sender_wallet)
-                    .store_maybe_ref(null())
-                    .store_coins(transfer_fee())
-                    .store_uint(0, 1)
-                    .end_cell();
-
-                var ref_msg = begin_cell()
-                    .store_uint(0x10, 6)
-                    .store_slice(token_wallet_address)
-                    .store_coins(transfer_fee())
-                    .store_uint(0, 1 + 4 + 4 + 64 + 32 + 1 + 1)
-                    .store_ref(ref_transfer)
-                    .end_cell();
-                send_raw_message(ref_msg, 1);
             }
         }
 
@@ -220,7 +170,7 @@ slice token_wallet_address
                 send_raw_message(msg, 1);
 
 
-                store_data(new_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, token_wallet_address);
+                store_data(new_ref, next_ticket_index, admin_address, price, token_wallet_address);
                 return();
 
                 ;; Отправить сообщение админу
@@ -231,7 +181,7 @@ slice token_wallet_address
             if (major < 3) { ;; Выигрышей Major меньше 3
                 major += 1;
                 next_ticket_index += 1;
-                send_winning(MAJOR_PRIZE(), player_address, 1, collection_address, 1, token_wallet_address);
+                send_winning(MAJOR_PRIZE(), player_address, 1, token_wallet_address);
 
                 cell new_ref = begin_cell()
                     .store_uint(jp, 16)
@@ -242,7 +192,7 @@ slice token_wallet_address
                     .store_uint(low, 16)
                     .store_uint(mini, 16)
                     .end_cell();
-                store_data(new_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, token_wallet_address);
+                store_data(new_ref, next_ticket_index, admin_address, price, token_wallet_address);
                 return();
             }
         }
@@ -252,7 +202,7 @@ slice token_wallet_address
                 next_ticket_index += 1;
                 high += 1;
 
-                send_winning(HIGH_PRIZE(), player_address, 2, collection_address, 2, token_wallet_address);
+                send_winning(HIGH_PRIZE(), player_address, 2, token_wallet_address);
 
                 cell new_ref = begin_cell()
                     .store_uint(jp, 16)
@@ -263,7 +213,7 @@ slice token_wallet_address
                     .store_uint(low, 16)
                     .store_uint(mini, 16)
                     .end_cell();
-                store_data(new_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, token_wallet_address);
+                store_data(new_ref, next_ticket_index, admin_address, price, token_wallet_address);
                 return();
             }
         }
@@ -273,7 +223,7 @@ slice token_wallet_address
                 next_ticket_index += 1;
                 mid += 1;
 
-                send_winning(MID_PRIZE(), player_address, 3, collection_address, 3, token_wallet_address);
+                send_winning(MID_PRIZE(), player_address, 3, token_wallet_address);
 
                 cell new_ref = begin_cell()
                     .store_uint(jp, 16)
@@ -284,7 +234,7 @@ slice token_wallet_address
                     .store_uint(low, 16)
                     .store_uint(mini, 16)
                     .end_cell();
-                store_data(new_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, token_wallet_address);
+                store_data(new_ref, next_ticket_index, admin_address, price, token_wallet_address);
                 return();
             }
         }
@@ -294,7 +244,7 @@ slice token_wallet_address
                 next_ticket_index += 1;
                 low_mid += 1;
 
-                send_winning(LOW_MID_PRIZE(), player_address, 4, collection_address, 4, token_wallet_address);
+                send_winning(LOW_MID_PRIZE(), player_address, 4, token_wallet_address);
 
                 cell new_ref = begin_cell()
                     .store_uint(jp, 16)
@@ -305,7 +255,7 @@ slice token_wallet_address
                     .store_uint(low, 16)
                     .store_uint(mini, 16)
                     .end_cell();
-                store_data(new_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, token_wallet_address);
+                store_data(new_ref, next_ticket_index, admin_address, price, token_wallet_address);
                 return();
             }
         }
@@ -315,7 +265,7 @@ slice token_wallet_address
                 next_ticket_index += 1;
                 low += 1;
 
-                send_winning(LOW_PRIZE(), player_address, 5, collection_address, 5, token_wallet_address);
+                send_winning(LOW_PRIZE(), player_address, 5, token_wallet_address);
 
                 cell new_ref = begin_cell()
                     .store_uint(jp, 16)
@@ -326,7 +276,7 @@ slice token_wallet_address
                     .store_uint(low, 16)
                     .store_uint(mini, 16)
                     .end_cell();
-                store_data(new_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, token_wallet_address);
+                store_data(new_ref, next_ticket_index, admin_address, price, token_wallet_address);
                 return();
             }
         }
@@ -336,7 +286,7 @@ slice token_wallet_address
                 next_ticket_index += 1;
                 mini += 1;
 
-                send_winning(MINI_PRIZE(), player_address, 6, collection_address, 6, token_wallet_address);
+                send_winning(MINI_PRIZE(), player_address, 6, token_wallet_address);
 
                 cell new_ref = begin_cell()
                     .store_uint(jp, 16)
@@ -347,16 +297,16 @@ slice token_wallet_address
                     .store_uint(low, 16)
                     .store_uint(mini, 16)
                     .end_cell();
-                store_data(new_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, token_wallet_address);
+                store_data(new_ref, next_ticket_index, admin_address, price, token_wallet_address);
                 return();
             }
         }
 
         next_ticket_index += 1;
 
-        send_winning(0, player_address, 7, collection_address, 7, token_wallet_address);
+        send_winning(0, player_address, 7, token_wallet_address);
 
-        store_data(counters_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, token_wallet_address);
+        store_data(counters_ref, next_ticket_index, admin_address, price, token_wallet_address);
 
         return();
     }
@@ -384,7 +334,7 @@ slice token_wallet_address
 
     if (op == 3) { ;; change_admin_address
     throw_unless(401, equal_slices(sender_address,admin_address));
-    store_data(counters_ref, next_ticket_index, collection_address, in_msg_body~load_msg_addr(), price, ref_percent, token_wallet_address);
+    store_data(counters_ref, next_ticket_index, in_msg_body~load_msg_addr(), price, token_wallet_address);
     return();
     }
 
@@ -401,7 +351,7 @@ slice token_wallet_address
     int low = counters_slice~load_uint(16);
     int mini = counters_slice~load_uint(16);
 
-    send_winning(JACKPOT_PRIZE(), winner, 0, collection_address, 0, token_wallet_address);
+    send_winning(JACKPOT_PRIZE(), winner, 0, token_wallet_address);
 
     jp += 1;
 
@@ -415,19 +365,19 @@ slice token_wallet_address
     .store_uint(mini, 16)
     .end_cell();
 
-    store_data(new_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, token_wallet_address);
+    store_data(new_ref, next_ticket_index, admin_address, price, token_wallet_address);
     return();
     }
 
     if (op == 5) { ;; set token_wallet_address
     throw_unless(401, equal_slices(sender_address, admin_address));
-    store_data(counters_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, in_msg_body~load_msg_addr());
+    store_data(counters_ref, next_ticket_index, admin_address, price, in_msg_body~load_msg_addr());
     return();
     }
 }
 
 (int, int, int, int, int, int, int) get_counters() method_id {
-    (cell counters_ref, _, _, _, _, _, _) = load_data();
+    (cell counters_ref, _, _, _, _) = load_data();
 
     slice counters_slice = counters_ref.begin_parse();
     int jp = counters_slice~load_uint(16);
@@ -449,24 +399,20 @@ slice token_wallet_address
 }
 
 
-(cell, int, slice, slice, int, int, slice) get_full_data() method_id {
+(cell, int, slice, int, slice) get_full_data() method_id {
     var (
         cell counters_ref,
         int next_ticket_index,
-        slice collection_address,
         slice admin_address,
         int price,
-        int ref_percent,
         slice token_wallet_address
     ) = load_data();
 
     return (
         counters_ref,
         next_ticket_index,
-        collection_address,
         admin_address,
         price,
-        ref_percent,
         token_wallet_address
     );
 }

--- a/tests/Jet.spec.ts
+++ b/tests/Jet.spec.ts
@@ -47,8 +47,7 @@ describe('Jet', () => {
 
     const ticketPrice = 10n * 1_000_000n;
 
-    async function deployLottery(options?: { refPercent?: number; counters?: number[] }) {
-        const refPercent = options?.refPercent ?? 0;
+    async function deployLottery(options?: { counters?: number[] }) {
         const counters = options?.counters ?? [0, 0, 0, 0, 0, 0, 0];
 
         const countersCell = beginCell()
@@ -65,9 +64,7 @@ describe('Jet', () => {
             .storeRef(countersCell)
             .storeUint(0, 64)
             .storeAddress(deployer.address)
-            .storeAddress(deployer.address)
             .storeUint(ticketPrice, 128)
-            .storeUint(refPercent, 16)
             .storeAddress(deployer.address)
             .endCell();
 
@@ -171,35 +168,6 @@ describe('Jet', () => {
         expectJettonTransfer(result.transactions, playerWalletAddress);
     });
 
-    it('should reward referral address', async () => {
-        jet = await deployLottery({ refPercent: 10 });
-        jetWalletAddress = await jettonMaster.getWalletAddress(jet.address);
-        await jettonMaster.sendDeployWallet(deployer.getSender(), jet.address, toNano('0.05'));
-        await jet.sendSetTokenWalletAddress(deployer.getSender(), jetWalletAddress, toNano('0.01'));
-        await jettonMaster.sendMint(deployer.getSender(), jetWalletAddress, 1_000_000_000n);
-
-        const player = await blockchain.treasury('player');
-        const referral = await blockchain.treasury('ref');
-        const playerWalletAddress = await jettonMaster.getWalletAddress(player.address);
-        const refWalletAddress = await jettonMaster.getWalletAddress(referral.address);
-        await jettonMaster.sendDeployWallet(deployer.getSender(), player.address, toNano('0.05'));
-        await jettonMaster.sendDeployWallet(deployer.getSender(), referral.address, toNano('0.05'));
-        await jettonMaster.sendMint(deployer.getSender(), playerWalletAddress, 20n * 1_000_000n);
-
-        const playerWallet = blockchain.openContract(JettonWallet.createFromAddress(playerWalletAddress));
-
-        const forwardPayload = beginCell().storeAddress(player.address).storeAddress(referral.address).endCell();
-
-        const result = await playerWallet.sendTransfer(player.getSender(), {
-            amount: ticketPrice,
-            destination: jet.address,
-            responseAddress: player.address,
-            forwardAmount: toNano('0.3'),
-            forwardPayload,
-        });
-
-        expectJettonTransfer(result.transactions, refWalletAddress);
-    });
 
     it('should not send prize when limits exceeded', async () => {
         jet = await deployLottery({ counters: [0, 3, 10, 35, 35, 30, 7] });

--- a/tests/RecvInternal.spec.ts
+++ b/tests/RecvInternal.spec.ts
@@ -17,7 +17,7 @@ function buildJettonTransfer(amount: bigint, wallet: Address, payload: Cell) {
         .endCell();
 }
 
-async function createContract(options?: { counters?: number[]; refPercent?: number; rand?: number }) {
+async function createContract(options?: { counters?: number[]; rand?: number }) {
     const code = await compile('Jet');
     const counters = options?.counters ?? [0, 0, 0, 0, 0, 0, 0];
     const countersCell = beginCell()
@@ -31,10 +31,8 @@ async function createContract(options?: { counters?: number[]; refPercent?: numb
         .endCell();
 
     const data = jetConfigToCell({
-        collectionAddress: Address.parse('0:' + '0'.repeat(64)),
         adminAddress: '0:' + '1'.repeat(64),
         price: ticketPrice,
-        refPercent: options?.refPercent ?? 0,
         tokenAddress: Address.parse('0:' + '2'.repeat(64)),
     });
     // replace counters in generated cell
@@ -72,18 +70,6 @@ describe('recv_internal direct', () => {
         expect(fwd.loadUint(32)).toBe(0x5052495a);
     });
 
-    it('pays referral address when provided', async () => {
-        const contract = await createContract({ refPercent: 10, rand: 1 });
-        const player = Address.parse('0:' + '3'.repeat(64));
-        const ref = Address.parse('0:' + '4'.repeat(64));
-        const payload = beginCell().storeAddress(player).storeAddress(ref).endCell();
-        const body = buildJettonTransfer(ticketPrice, player, payload);
-        const msg = internal({ to: contract.address, from: player, value: playerFee, bounce: true, body });
-        const trace = await contract.sendInternalMessage(msg);
-        expect(trace.exitCode).toBe(0);
-        const hasRefTransfer = trace.outMessages.some(m => m.info.dest?.toString() === ref.toString());
-        expect(hasRefTransfer).toBe(true);
-    });
 
     it('skips transfer when prizes exhausted', async () => {
         const counters = [0, 3, 10, 35, 35, 30, 7];
@@ -97,15 +83,5 @@ describe('recv_internal direct', () => {
         expect(trace.outMessages.length).toBe(0);
     });
 
-    it('handles USDT style transfer with ref payload', async () => {
-        const contract = await createContract({ refPercent: 10, rand: 1 });
-        const player = Address.parse('0:' + '3'.repeat(64));
-        const ref = Address.parse('0:' + '4'.repeat(64));
-        const payload = beginCell().storeAddress(ref).endCell();
-        const body = buildJettonTransfer(ticketPrice, player, payload);
-        const msg = internal({ to: contract.address, from: player, value: playerFee, bounce: true, body, state: null, isRight: true });
-        const trace = await contract.sendInternalMessage(msg);
-        expect(trace.exitCode).toBe(0);
-    });
 });
 

--- a/wrappers/Jet.ts
+++ b/wrappers/Jet.ts
@@ -1,10 +1,8 @@
 import { Address, beginCell, Cell, Contract, contractAddress, ContractProvider, Sender, SendMode } from '@ton/core';
 
 export type JetConfig = {
-    collectionAddress: Address;
     adminAddress: string;
     price: bigint;
-    refPercent: number;
     tokenAddress: Address;
 };
 
@@ -22,10 +20,8 @@ export function jetConfigToCell(config: JetConfig): Cell {
             .endCell()
         )
         .storeUint(0, 64)
-        .storeAddress(config.collectionAddress)
         .storeAddress(Address.parse(config.adminAddress))
         .storeUint(config.price, 128)
-        .storeUint(config.refPercent, 16)
         .storeAddress(config.tokenAddress)
         .endCell()
 }


### PR DESCRIPTION
## Summary
- drop NFT minting and referral logic
- adjust `send_winning` to use stablecoin-style transfer
- update Jet config and wrappers
- prune tests for removed functionality
- update docs for simplified flow

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6842f6e0db3083258d9ccf5a60c27754