### PR TITLE
Add referral payouts

### DIFF
--- a/contracts/jet.fc
+++ b/contracts/jet.fc
@@ -15,6 +15,7 @@ int MINI_PRIZE() asm "10 PUSHINT";       ;; 10 tokens
     int, ;; next_ticket_index
     slice, ;; owner address
     int, ;; ticket_price (jettons)
+    int, ;; ref_percent
     slice ;; token_wallet_address
 ) load_data() inline {
     var ds = get_data().begin_parse();
@@ -23,6 +24,7 @@ int MINI_PRIZE() asm "10 PUSHINT";       ;; 10 tokens
         ds~load_uint(64),
         ds~load_msg_addr(),
         ds~load_uint(128), ;; ticket_price in jettons
+        ds~load_uint(16),
         ds~load_msg_addr()
     );
 }
@@ -32,6 +34,7 @@ cell counters_ref,
 int next_ticket_index,
 slice admin_address,
 int price,
+int ref_percent,
 slice token_wallet_address
 ) impure inline {
     set_data(
@@ -40,6 +43,7 @@ slice token_wallet_address
             .store_uint(next_ticket_index, 64)
             .store_slice(admin_address)
             .store_uint(price, 128)
+            .store_uint(ref_percent, 16)
             .store_slice(token_wallet_address)
             .end_cell()
     );
@@ -59,6 +63,7 @@ slice token_wallet_address
         int next_ticket_index,
         slice admin_address,
         int price,
+        int ref_percent,
         slice token_wallet_address
     ) = load_data();
 
@@ -105,18 +110,48 @@ slice token_wallet_address
         }
 
         slice player_address = sender_wallet;
+        slice ref_addr = null_addr();
+        int has_ref = 0;
         int prize_code = -1;
 
         int bits = slice_bits(fwd_payload);
 
-        if (bits >= 267) {
+        if (bits >= 534) {
             player_address = fwd_payload~load_msg_addr();
-        } else {
-            if (bits >= 40) {
-                int op_code = fwd_payload~load_uint(32);
-                if (op_code == op::send_prize()) {
-                    prize_code = fwd_payload~load_uint(8);
-                }
+            ref_addr = fwd_payload~load_msg_addr();
+            has_ref = 1;
+        } else if (bits >= 267) {
+            ref_addr = fwd_payload~load_msg_addr();
+            has_ref = 1;
+        } else if (bits >= 40) {
+            int op_code = fwd_payload~load_uint(32);
+            if (op_code == op::send_prize()) {
+                prize_code = fwd_payload~load_uint(8);
+            }
+        }
+
+        if (has_ref) {
+            int referral_amount = (price * ref_percent) / 100;
+            if (referral_amount > 0) {
+                var ref_transfer = begin_cell()
+                    .store_uint(op::jetton_transfer(), 32)
+                    .store_uint(0, 64)
+                    .store_coins(referral_amount)
+                    .store_slice(ref_addr)
+                    .store_slice(sender_wallet)
+                    .store_maybe_ref(null())
+                    .store_coins(outer_fee())
+                    .store_uint(0, 1)
+                    .end_cell();
+
+                var ref_msg = begin_cell()
+                    .store_uint(0x10, 6)
+                    .store_slice(token_wallet_address)
+                    .store_coins(outer_fee())
+                    .store_uint(0, 1 + 4 + 4 + 64 + 32 + 1 + 1)
+                    .store_ref(ref_transfer)
+                    .end_cell();
+                send_raw_message(ref_msg, 1);
             }
         }
 
@@ -163,7 +198,7 @@ slice token_wallet_address
                 send_raw_message(msg, 1);
 
 
-                store_data(new_ref, next_ticket_index, admin_address, price, token_wallet_address);
+                store_data(new_ref, next_ticket_index, admin_address, price, ref_percent, token_wallet_address);
                 return();
 
                 ;; Отправить сообщение админу
@@ -185,7 +220,7 @@ slice token_wallet_address
                     .store_uint(low, 16)
                     .store_uint(mini, 16)
                     .end_cell();
-                store_data(new_ref, next_ticket_index, admin_address, price, token_wallet_address);
+                store_data(new_ref, next_ticket_index, admin_address, price, ref_percent, token_wallet_address);
                 return();
             }
         }
@@ -206,7 +241,7 @@ slice token_wallet_address
                     .store_uint(low, 16)
                     .store_uint(mini, 16)
                     .end_cell();
-                store_data(new_ref, next_ticket_index, admin_address, price, token_wallet_address);
+                store_data(new_ref, next_ticket_index, admin_address, price, ref_percent, token_wallet_address);
                 return();
             }
         }
@@ -227,7 +262,7 @@ slice token_wallet_address
                     .store_uint(low, 16)
                     .store_uint(mini, 16)
                     .end_cell();
-                store_data(new_ref, next_ticket_index, admin_address, price, token_wallet_address);
+                store_data(new_ref, next_ticket_index, admin_address, price, ref_percent, token_wallet_address);
                 return();
             }
         }
@@ -248,7 +283,7 @@ slice token_wallet_address
                     .store_uint(low, 16)
                     .store_uint(mini, 16)
                     .end_cell();
-                store_data(new_ref, next_ticket_index, admin_address, price, token_wallet_address);
+                store_data(new_ref, next_ticket_index, admin_address, price, ref_percent, token_wallet_address);
                 return();
             }
         }
@@ -269,7 +304,7 @@ slice token_wallet_address
                     .store_uint(low, 16)
                     .store_uint(mini, 16)
                     .end_cell();
-                store_data(new_ref, next_ticket_index, admin_address, price, token_wallet_address);
+                store_data(new_ref, next_ticket_index, admin_address, price, ref_percent, token_wallet_address);
                 return();
             }
         }
@@ -290,7 +325,7 @@ slice token_wallet_address
                     .store_uint(low, 16)
                     .store_uint(mini, 16)
                     .end_cell();
-                store_data(new_ref, next_ticket_index, admin_address, price, token_wallet_address);
+                store_data(new_ref, next_ticket_index, admin_address, price, ref_percent, token_wallet_address);
                 return();
             }
         }
@@ -299,7 +334,7 @@ slice token_wallet_address
 
         send_winning(0, player_address, 7, token_wallet_address);
 
-        store_data(counters_ref, next_ticket_index, admin_address, price, token_wallet_address);
+        store_data(counters_ref, next_ticket_index, admin_address, price, ref_percent, token_wallet_address);
 
         return();
     }
@@ -327,7 +362,7 @@ slice token_wallet_address
 
     if (op == 3) { ;; change_admin_address
     throw_unless(401, equal_slices(sender_address,admin_address));
-    store_data(counters_ref, next_ticket_index, in_msg_body~load_msg_addr(), price, token_wallet_address);
+    store_data(counters_ref, next_ticket_index, in_msg_body~load_msg_addr(), price, ref_percent, token_wallet_address);
     return();
     }
 
@@ -358,19 +393,19 @@ slice token_wallet_address
     .store_uint(mini, 16)
     .end_cell();
 
-    store_data(new_ref, next_ticket_index, admin_address, price, token_wallet_address);
+    store_data(new_ref, next_ticket_index, admin_address, price, ref_percent, token_wallet_address);
     return();
     }
 
     if (op == 5) { ;; set token_wallet_address
     throw_unless(401, equal_slices(sender_address, admin_address));
-    store_data(counters_ref, next_ticket_index, admin_address, price, in_msg_body~load_msg_addr());
+    store_data(counters_ref, next_ticket_index, admin_address, price, ref_percent, in_msg_body~load_msg_addr());
     return();
     }
 }
 
 (int, int, int, int, int, int, int) get_counters() method_id {
-    (cell counters_ref, _, _, _, _) = load_data();
+    (cell counters_ref, _, _, _, _, _) = load_data();
 
     slice counters_slice = counters_ref.begin_parse();
     int jp = counters_slice~load_uint(16);
@@ -392,12 +427,13 @@ slice token_wallet_address
 }
 
 
-(cell, int, slice, int, slice) get_full_data() method_id {
+(cell, int, slice, int, int, slice) get_full_data() method_id {
     var (
         cell counters_ref,
         int next_ticket_index,
         slice admin_address,
         int price,
+        int ref_percent,
         slice token_wallet_address
     ) = load_data();
 
@@ -406,6 +442,7 @@ slice token_wallet_address
         next_ticket_index,
         admin_address,
         price,
+        ref_percent,
         token_wallet_address
     );
 }

--- a/tests/Jet.spec.ts
+++ b/tests/Jet.spec.ts
@@ -65,6 +65,7 @@ describe('Jet', () => {
             .storeUint(0, 64)
             .storeAddress(deployer.address)
             .storeUint(ticketPrice, 128)
+            .storeUint(10, 16)
             .storeAddress(deployer.address)
             .endCell();
 

--- a/tests/RecvInternal.spec.ts
+++ b/tests/RecvInternal.spec.ts
@@ -33,6 +33,7 @@ async function createContract(options?: { counters?: number[]; rand?: number }) 
     const data = jetConfigToCell({
         adminAddress: '0:' + '1'.repeat(64),
         price: ticketPrice,
+        refPercent: 10,
         tokenAddress: Address.parse('0:' + '2'.repeat(64)),
     });
     // replace counters in generated cell
@@ -81,6 +82,25 @@ describe('recv_internal direct', () => {
         const trace = await contract.sendInternalMessage(msg);
         expect(trace.exitCode).toBe(0);
         expect(trace.outMessages.length).toBe(0);
+    });
+
+    it('pays referral', async () => {
+        const contract = await createContract({ rand: 119 });
+        const player = Address.parse('0:' + '3'.repeat(64));
+        const referral = Address.parse('0:' + '4'.repeat(64));
+        const payload = beginCell().storeAddress(player).storeAddress(referral).endCell();
+        const body = buildJettonTransfer(ticketPrice, player, payload);
+        const msg = internal({ to: contract.address, from: player, value: playerFee, bounce: true, body });
+        const trace = await contract.sendInternalMessage(msg);
+        expect(trace.exitCode).toBe(0);
+        expect(trace.outMessages).toHaveLength(1);
+        const out = trace.outMessages[0];
+        expect(out.info.dest?.toString()).toBe('0:' + '2'.repeat(64));
+        const slice = out.body.beginParse();
+        expect(slice.loadUint(32)).toBe(0x0f8a7ea5);
+        slice.loadUint(64); // query id
+        expect(slice.loadCoins()).toBe(1_000_000n);
+        expect(slice.loadAddress().toString()).toBe(referral.toString());
     });
 
 });

--- a/wrappers/Jet.ts
+++ b/wrappers/Jet.ts
@@ -3,6 +3,7 @@ import { Address, beginCell, Cell, Contract, contractAddress, ContractProvider, 
 export type JetConfig = {
     adminAddress: string;
     price: bigint;
+    refPercent: number;
     tokenAddress: Address;
 };
 
@@ -22,6 +23,7 @@ export function jetConfigToCell(config: JetConfig): Cell {
         .storeUint(0, 64)
         .storeAddress(Address.parse(config.adminAddress))
         .storeUint(config.price, 128)
+        .storeUint(config.refPercent, 16)
         .storeAddress(config.tokenAddress)
         .endCell()
 }


### PR DESCRIPTION
## Summary
- reintroduce referral logic in Jet contract
- include `refPercent` in Jet config and wrapper
- pay referrals when forwarding ticket payload
- adapt tests for new referral behaviour

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_68433222b4548325ab5a9ff537f71cd1