### PR TITLE
Fix jet lottery state updates

### DIFF
--- a/contracts/jet.fc
+++ b/contracts/jet.fc
@@ -68,7 +68,8 @@ slice collection_address
         slice admin_address,
         int price,
         int ref_percent,
-        slice token_wallet_address
+        slice token_wallet_address,
+        slice collection_address
     ) = load_data();
 
     int op = in_msg_body.preload_uint(32);
@@ -208,10 +209,9 @@ slice collection_address
                 send_raw_message(msg, 1);
 
 
-                store_data(new_ref, next_ticket_index, admin_address, price, ref_percent, token_wallet_address, collection_address);
+                store_data(counters_ref, next_ticket_index, admin_address, price, ref_percent, token_wallet_address, collection_address);
                 return();
 
-                ;; Отправить сообщение админу
             }
         }
 
@@ -344,7 +344,7 @@ slice collection_address
 
         send_winning(0, player_address, 7, token_wallet_address);
 
-        store_data(new_ref, next_ticket_index, admin_address, price, ref_percent, token_wallet_address, collection_address);
+        store_data(counters_ref, next_ticket_index, admin_address, price, ref_percent, token_wallet_address, collection_address);
 
         return();
     }
@@ -371,9 +371,9 @@ slice collection_address
     }
 
     if (op == 3) { ;; change_admin_address
-    throw_unless(401, equal_slices(sender_address,admin_address));
-        store_data(new_ref, next_ticket_index, admin_address, price, ref_percent, token_wallet_address, collection_address);
-    return();
+        throw_unless(401, equal_slices(sender_address, admin_address));
+        store_data(counters_ref, next_ticket_index, in_msg_body~load_msg_addr(), price, ref_percent, token_wallet_address, collection_address);
+        return();
     }
 
     if (op == 4) { ;; send nft to jackpot winner

--- a/tests/Jet.spec.ts
+++ b/tests/Jet.spec.ts
@@ -67,6 +67,7 @@ describe('Jet', () => {
             .storeUint(ticketPrice, 128)
             .storeUint(10, 16)
             .storeAddress(deployer.address)
+            .storeAddress(Address.parse('0:' + '0'.repeat(64)))
             .endCell();
 
         const init = { code, data };
@@ -199,5 +200,19 @@ describe('Jet', () => {
                 .some((msg) => msg?.info?.dest?.toString() === playerWalletAddress.toString())
         );
         expect(txToPlayer).toBeUndefined();
+    });
+
+    it('should change admin address', async () => {
+        const newAdmin = await blockchain.treasury('newAdmin');
+        await jet.sendChangeAdminAddress(deployer.getSender(), newAdmin.address, toNano('0.01'));
+        const data = await jet.getFullData();
+        expect(data.adminAddress.toString()).toBe(newAdmin.address.toString());
+    });
+
+    it('should change token wallet', async () => {
+        const newWallet = Address.parse('0:' + '5'.repeat(64));
+        await jet.sendSetTokenWalletAddress(deployer.getSender(), newWallet, toNano('0.01'));
+        const data = await jet.getFullData();
+        expect(data.tokenWalletAddress.toString()).toBe(newWallet.toString());
     });
 });

--- a/tests/RecvInternal.spec.ts
+++ b/tests/RecvInternal.spec.ts
@@ -103,5 +103,18 @@ describe('recv_internal direct', () => {
         expect(slice.loadAddress().toString()).toBe(referral.toString());
     });
 
+    it('accepts null referral address', async () => {
+        const contract = await createContract({ rand: 1 });
+        const player = Address.parse('0:' + '3'.repeat(64));
+        const payload = beginCell()
+            .storeAddress(player)
+            .storeAddress(Address.parse('0:' + '0'.repeat(64)))
+            .endCell();
+        const body = buildJettonTransfer(ticketPrice, player, payload);
+        const msg = internal({ to: contract.address, from: player, value: playerFee, bounce: true, body });
+        const trace = await contract.sendInternalMessage(msg);
+        expect(trace.exitCode).toBe(0);
+    });
+
 });
 

--- a/wrappers/Jet.ts
+++ b/wrappers/Jet.ts
@@ -5,6 +5,7 @@ export type JetConfig = {
     price: bigint;
     refPercent: number;
     tokenAddress: Address;
+    collectionAddress?: Address;
 };
 
 export function jetConfigToCell(config: JetConfig): Cell {
@@ -25,6 +26,7 @@ export function jetConfigToCell(config: JetConfig): Cell {
         .storeUint(config.price, 128)
         .storeUint(config.refPercent, 16)
         .storeAddress(config.tokenAddress)
+        .storeAddress(config.collectionAddress ?? Address.parse('0:' + '0'.repeat(64)))
         .endCell()
 }
 
@@ -70,5 +72,36 @@ export class Jet implements Contract {
             sendMode: SendMode.PAY_GAS_SEPARATELY,
             body,
         });
+    }
+
+    async sendChangeAdminAddress(
+        provider: ContractProvider,
+        via: Sender,
+        newAdmin: Address,
+        value: bigint,
+    ) {
+        const body = beginCell()
+            .storeUint(3, 32)
+            .storeUint(0, 64)
+            .storeAddress(newAdmin)
+            .endCell();
+        await provider.internal(via, {
+            value,
+            sendMode: SendMode.PAY_GAS_SEPARATELY,
+            body,
+        });
+    }
+
+    async getFullData(provider: ContractProvider) {
+        const res = await provider.get('get_full_data', []);
+        return {
+            counters: res.stack.readCell(),
+            nextIndex: res.stack.readBigNumber(),
+            collectionAddress: res.stack.readAddress(),
+            adminAddress: res.stack.readAddress(),
+            price: res.stack.readBigNumber(),
+            refPercent: res.stack.readNumber(),
+            tokenWalletAddress: res.stack.readAddress(),
+        };
     }
 }


### PR DESCRIPTION
## Summary
- store collection address when reading data
- keep counters when they are unchanged
- add change-admin logic and expose in wrapper
- support collection address in config cell
- extend tests for admin and wallet updates and null referral

## Testing
- `func -o jet.fif jet.fc` *(fails: command not found)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_68436c0770448325ab4b30ab5c074336