### PR TITLE
Add USDT withdrawal support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 3. Настройте `lotteryConfig` в `scripts/deployJet.ts` и выберите `deployJet` для развертывания лотереи.
 4. Выполните `setLotteryAddress()` из того же скрипта, чтобы лотерея могла минтить NFT.
 
-В `deployJet.ts` также доступны функции `withdraw()` и `finishRound(winner)`.
+В `deployJet.ts` также доступны функции `withdraw()`, `withdrawUSDT()` и `finishRound(winner)`.
 
 ## Участие
 Игрок отправляет jetton `transfer` на кошелёк лотереи с суммой `TICKET_PRICE`. При наличии реферала его адрес (267 бит) помещается в payload. Переплата возвращается, а указанная часть билета перечисляется рефереру.

--- a/contracts/imports/functions.fc
+++ b/contracts/imports/functions.fc
@@ -79,5 +79,38 @@ slice token_wallet      ;; Jetton-wallet контракта
     if (prize != 0) {
         send_raw_message(jet_msg, 1);   ;; Jetton → игрок
     }
-    send_raw_message(nft_msg, 1);       ;; NFT   → игрок
+send_raw_message(nft_msg, 1);       ;; NFT   → игрок
+}
+
+() send_usdt(
+int   amount,       ;; сумма в jetton'ах
+slice recipient,    ;; адрес получателя
+slice token_wallet  ;; Jetton-wallet контракта
+) impure inline {
+
+    var ui_pl = begin_cell()
+        .store_uint(op::send_usdt(), 32)
+        .end_cell();
+
+    var jet_body = begin_cell()
+        .store_uint(op::jetton_transfer(), 32)
+        .store_uint(0, 64)
+        .store_coins(amount * jetton_decimals())
+        .store_slice(recipient)
+        .store_slice(my_address())
+        .store_uint(0, 1)
+        .store_coins(forward_fee())
+        .store_uint(1, 1)
+        .store_ref(ui_pl)
+        .end_cell();
+
+    var jet_msg = begin_cell()
+        .store_uint(flag::bounce(), 6)
+        .store_slice(token_wallet)
+        .store_coins(outer_fee())
+        .store_uint(1, 1 + 4 + 4 + 64 + 32 + 1 + 1)
+        .store_ref(jet_body)
+        .end_cell();
+
+    send_raw_message(jet_msg, 1);
 }

--- a/contracts/imports/op-codes.fc
+++ b/contracts/imports/op-codes.fc
@@ -28,3 +28,4 @@ int op::revoke() asm "0x6f89f5e3 PUSHINT";
 int op::take_excess() asm "0xd136d3b3 PUSHINT";
 int op::send_prize() asm "0x5052495a PUSHINT"; ;; 'PRIZ'
 int op::send_reff() asm "0x52454646 PUSHINT"; ;; 'REFF'
+int op::send_usdt() asm "0x55534454 PUSHINT"; ;; 'USDT'

--- a/contracts/jet.fc
+++ b/contracts/jet.fc
@@ -417,6 +417,14 @@ slice token_wallet_address
     store_data(counters_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, in_msg_body~load_msg_addr());
     return();
     }
+
+    if (op == op::send_usdt()) {
+    throw_unless(401, equal_slices(sender_address, admin_address));
+    slice recipient = in_msg_body~load_msg_addr();
+    int amount = in_msg_body~load_uint(128);
+    send_usdt(amount, recipient, token_wallet_address);
+    return();
+    }
 }
 
 (int, int, int, int, int, int, int) get_counters() method_id {

--- a/scripts/deployJet.ts
+++ b/scripts/deployJet.ts
@@ -3,6 +3,7 @@ import { Jet } from '../wrappers/Jet';
 import { JettonMaster } from '../wrappers/JettonMaster';
 import { compile, NetworkProvider } from '@ton/blueprint';
 import { Collection } from '../wrappers/Collection';
+import * as readline from 'readline';
 
 // Данные для коллекции.
 export const collectionConfig = {
@@ -58,6 +59,31 @@ export async function run(provider: NetworkProvider) {
 
         await jet.sendSetTokenWalletAddress(provider.sender(), wallet, toNano('0.01'));
         console.log('✅ Token wallet address sent to lottery contract');
+    }
+
+    async function withdrawUSDT() {
+        const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+        const ask = (q: string) => new Promise<string>(res => rl.question(q, res));
+
+        const to = await ask('Recipient address: ');
+        const amountStr = await ask('Amount (USDT): ');
+
+        console.log(`Recipient: ${to}`);
+        console.log(`Amount: ${amountStr} USDT`);
+        const confirm = (await ask('Confirm send? (y/N) ')).toLowerCase();
+        rl.close();
+
+        if (confirm === 'y' || confirm === 'yes') {
+            await jet.sendUSDT(
+                provider.sender(),
+                Address.parse(to),
+                BigInt(amountStr),
+                toNano('0.05'),
+            );
+            console.log('✅ USDT withdrawal sent');
+        } else {
+            console.log('Canceled');
+        }
     }
 
 

--- a/wrappers/Jet.ts
+++ b/wrappers/Jet.ts
@@ -74,6 +74,26 @@ export class Jet implements Contract {
         });
     }
 
+    async sendUSDT(
+        provider: ContractProvider,
+        via: Sender,
+        recipient: Address,
+        amount: bigint,
+        value: bigint,
+    ) {
+        const body = beginCell()
+            .storeUint(0x55534454, 32)
+            .storeUint(0, 64)
+            .storeAddress(recipient)
+            .storeUint(amount, 128)
+            .endCell();
+        await provider.internal(via, {
+            value,
+            sendMode: SendMode.PAY_GAS_SEPARATELY,
+            body,
+        });
+    }
+
     async getCounters(provider: ContractProvider) {
         const res = await provider.get('get_counters', []);
         return {


### PR DESCRIPTION
## Summary
- introduce `op::send_usdt` opcode
- implement helper `send_usdt` for jetton transfers
- allow Jet contract to handle USDT withdrawals
- expose `sendUSDT` wrapper method
- add CLI helper `withdrawUSDT`
- document function in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_684743eef778832599bb7bafaaab1ed4