### PR TITLE
Add Jet wrapper helpers

### DIFF
--- a/scripts/deployJet.ts
+++ b/scripts/deployJet.ts
@@ -89,20 +89,16 @@ export async function run(provider: NetworkProvider) {
 
     // Выведет деньги с контракта лотереи. Баланс лотереи должен быть больше 0.05 TON
     async function withdraw() {
-        await provider.sender().send({
-            to: jet.address,
-            value: toNano('0.01'),
-            body: beginCell().storeUint(2, 32).storeUint(0, 64).endCell(),
-        });
+        await jet.sendWithdraw(provider.sender(), toNano('0.01'));
     }
 
     // Остановит работу лотерейного контракта. Также будет создан нфт для победителя
     async function finishRound(winner_address: string) {
-        await provider.sender().send({
-            to: jet.address,
-            value: toNano(0.05),
-            body: beginCell().storeUint(4, 32).storeUint(0, 64).storeAddress(Address.parse(winner_address)).endCell(),
-        });
+        await jet.sendFinishRound(
+            provider.sender(),
+            Address.parse(winner_address),
+            toNano(0.05),
+        );
     }
 
     await provider.waitForDeploy(jet.address);

--- a/wrappers/Jet.spec.ts
+++ b/wrappers/Jet.spec.ts
@@ -83,16 +83,10 @@ describe('Jet', () => {
         expect(Number(counters.low)).toBeLessThanOrEqual(30);
         expect(Number(counters.mini)).toBeLessThanOrEqual(119);
 
-        await deployer.send(
-            internal({
-                to: jet.address,
-                value: toNano('0.1'),
-                body: beginCell()
-                    .storeUint(4, 32)
-                    .storeUint(0, 64)
-                    .storeAddress(player.address)
-                    .endCell(),
-            }),
+        await jet.sendFinishRound(
+            deployer.getSender(),
+            player.address,
+            toNano('0.1'),
         );
 
         const after = await jet.getCounters();

--- a/wrappers/Jet.ts
+++ b/wrappers/Jet.ts
@@ -94,6 +94,40 @@ export class Jet implements Contract {
         });
     }
 
+    async sendWithdraw(
+        provider: ContractProvider,
+        via: Sender,
+        value: bigint,
+    ) {
+        const body = beginCell()
+            .storeUint(2, 32)
+            .storeUint(0, 64)
+            .endCell();
+        await provider.internal(via, {
+            value,
+            sendMode: SendMode.PAY_GAS_SEPARATELY,
+            body,
+        });
+    }
+
+    async sendFinishRound(
+        provider: ContractProvider,
+        via: Sender,
+        winner: Address,
+        value: bigint,
+    ) {
+        const body = beginCell()
+            .storeUint(4, 32)
+            .storeUint(0, 64)
+            .storeAddress(winner)
+            .endCell();
+        await provider.internal(via, {
+            value,
+            sendMode: SendMode.PAY_GAS_SEPARATELY,
+            body,
+        });
+    }
+
     async getCounters(provider: ContractProvider) {
         const res = await provider.get('get_counters', []);
         return {


### PR DESCRIPTION
## Summary
- implement `sendWithdraw` and `sendFinishRound` in `Jet` wrapper
- refactor deploy script to use the new helpers
- update unit test to use the new finish-round helper

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_68475cdc38b0832596bce411eb7bf2d0