### PR TITLE
Fix royalty send mode fee calculation

### DIFF
--- a/contracts/collection.fc
+++ b/contracts/collection.fc
@@ -65,7 +65,7 @@ slice calculate_nft_item_address(int wc, cell state_init) {
   var msg = begin_cell()
     .store_uint(0x10, 6) ;; nobounce - int_msg_info$0 ihr_disabled:Bool bounce:Bool bounced:Bool packages:MsgAddress -> 011000
     .store_slice(to_address)
-    .store_coins(transfer_fee())
+    .store_coins(0)
     .store_uint(1, 1 + 4 + 4 + 64 + 32 + 1 + 1)
     .store_uint(op::report_royalty_params(), 32)
     .store_uint(query_id, 64)


### PR DESCRIPTION
## Summary
- fix `send_royalty_params` to not attach extra transfer fee when carrying all inbound value