### PR TITLE
Fix gas usage in Jet contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ for all other tiers stay the same. Win notifications are broadcast live via
 
 4. After the prize is issued, one of the counters `jp`, `major`, `high`, `mid`, `low_mid`, `low`, `mini` is increased. The NFT is minted from the collection and the jetton prize is sent to the player.
 5. The contract must always keep at least 0.05 TON and enough jettons for future payouts.
-6. When sending a ticket, store your TON wallet address first in `forward_payload`, followed by an optional referrer address. Set `forward_ton_amount` to at least `0.27` TON.
+6. When sending a ticket, store your TON wallet address first in `forward_payload`, followed by an optional referrer address. The Jet contract now checks that at least `0.27` TON is attached, so set `forward_ton_amount` to this `min_ticket_value` or higher.
 
 ## Technology Stack
 - **FunC** for smart contracts

--- a/contracts/imports/params.fc
+++ b/contracts/imports/params.fc
@@ -13,4 +13,5 @@ int outer_fee() asm "150000000 PUSHINT";    ;; 0.15 TON
 ;; 0.05 TON пересылаем игроку вместе с jetton-transfer
 int forward_fee() asm "50000000 PUSHINT";   ;; 0.05 TON
 int transfer_fee() asm "70000000 PUSHINT"; ;; 0.05 TON (maybe 0.07 TON is too small)
+int min_ticket_value() asm "270000000 PUSHINT"; ;; TON required to buy one ticket
 

--- a/contracts/jet.fc
+++ b/contracts/jet.fc
@@ -94,7 +94,7 @@ slice token_wallet_address
             fwd_payload = in_msg_body~load_ref().begin_parse();
         }
 
-        throw_unless(400, msg_value >= player_fee());
+        throw_unless(400, msg_value >= min_ticket_value());
 
         throw_unless(400, amount >= price);
 
@@ -107,14 +107,14 @@ slice token_wallet_address
                 .store_slice(sender_wallet)
                 .store_slice(my_address())
                 .store_maybe_ref(null())
-                .store_coins(forward_fee())
+                .store_coins(1)
                 .store_uint(0, 1)
                 .end_cell();
 
             var refund_msg = begin_cell()
                 .store_uint(0x10, 6)
                 .store_slice(token_wallet_address)
-                .store_coins(forward_fee())
+                .store_coins(1)
                 ;; payload stored in a reference -> body_ref flag must be 1
                 .store_uint(1, 1 + 4 + 4 + 64 + 32 + 1 + 1)
                 .store_ref(refund_transfer)

--- a/helpers/index.ts
+++ b/helpers/index.ts
@@ -37,7 +37,7 @@ export class JetContract {
             sendInternalMessage: async (body: Cell) => {
                 await tokenWallet.send({
                     to: contract.address,
-                    value: toNano('0.1'),
+                    value: toNano('0.27'),
                     body,
                 });
             },
@@ -63,7 +63,7 @@ export class JetContract {
             ),
         );
 
-        await contract.sendDeploy(deployer.getSender(), toNano('0.1'));
+        await contract.sendDeploy(deployer.getSender(), toNano('0.27'));
         return new JetContract(blockchain, deployer, tokenWallet, contract, ticketPrice);
     }
 

--- a/wrappers/Jet.spec.ts
+++ b/wrappers/Jet.spec.ts
@@ -28,7 +28,7 @@ describe('Jet', () => {
 
         await deployer.send({
             to: jet.address,
-            value: toNano('0.1'),
+            value: toNano('0.27'),
             body,
         });
     }
@@ -51,7 +51,7 @@ describe('Jet', () => {
             ),
         );
 
-        const deployResult = await jet.sendDeploy(deployer.getSender(), toNano('0.1'));
+        const deployResult = await jet.sendDeploy(deployer.getSender(), toNano('0.27'));
 
         expect(deployResult.transactions).toHaveTransaction({
             from: deployer.address,
@@ -86,7 +86,7 @@ describe('Jet', () => {
         const finish = await jet.sendFinishRound(
             deployer.getSender(),
             player.address,
-            toNano('0.1'),
+            toNano('0.27'),
         );
         expect(finish.transactions).toHaveTransaction({ exitCode: 0 });
 


### PR DESCRIPTION
## Summary
- require a new constant `min_ticket_value` covering all fees
- check `min_ticket_value` in `recv_internal`
- reduce forward ton amounts for refund transfers to 1 nanoton
- update docs and tests to send at least 0.27 TON with tickets

## Testing
- `npm install`
- `npm test`