### PR TITLE
Update jet.fc with jackpot token accounting

### DIFF
--- a/contracts/jet.fc
+++ b/contracts/jet.fc
@@ -16,7 +16,10 @@ int MINI_PRIZE() asm "10 PUSHINT";       ;; 10 tokens
     slice, ;; owner address
     int, ;; ticket_price (jettons)
     int, ;; ref_percent
-    slice ;; token_wallet_address
+    slice, ;; token_wallet_address
+    int,   ;; jp_amount
+    int,   ;; locked_jp_tokens
+    int    ;; token_balance
 ) load_data() inline {
     var ds = get_data().begin_parse();
     return (
@@ -26,7 +29,10 @@ int MINI_PRIZE() asm "10 PUSHINT";       ;; 10 tokens
         ds~load_msg_addr(),
         ds~load_uint(128), ;; ticket_price in jettons
         ds~load_uint(16),
-        ds~load_msg_addr()
+        ds~load_msg_addr(),
+        ds~load_uint(128),
+        ds~load_uint(128),
+        ds~load_uint(128)
     );
 }
 
@@ -38,6 +44,9 @@ slice admin_address,
 int price,
 int ref_percent,
 slice token_wallet_address
+int jp_amount,
+int locked_jp_tokens,
+int token_balance
 ) impure inline {
     set_data(
         begin_cell()
@@ -48,6 +57,9 @@ slice token_wallet_address
             .store_uint(price, 128)
             .store_uint(ref_percent, 16)
             .store_slice(token_wallet_address)
+            .store_uint(jp_amount, 128)
+            .store_uint(locked_jp_tokens, 128)
+            .store_uint(token_balance, 128)
             .end_cell()
     );
 }
@@ -73,7 +85,10 @@ slice token_wallet_address
         slice admin_address,
         int price,
         int ref_percent,
-        slice token_wallet_address
+        slice token_wallet_address,
+        int jp_amount,
+        int locked_jp_tokens,
+        int token_balance
     ) = load_data();
 
     int op = in_msg_body.preload_uint(32);
@@ -97,6 +112,10 @@ slice token_wallet_address
         throw_unless(400, msg_value >= min_ticket_value());
 
         throw_unless(400, amount >= price);
+        token_balance += amount;
+        if (locked_jp_tokens == 0) {
+            locked_jp_tokens := jp_amount;
+        }
 
         int excess = amount - price;
         if (excess > 0) {
@@ -197,8 +216,12 @@ slice token_wallet_address
 
         if (x == 0) { ;; Jackpot 1/12000
             if (jp == 0) { ;; Jackpot has not been claimed yet
+                throw_unless(402, token_balance >= locked_jp_tokens);
                 next_ticket_index += 1;
                  jp += 1;
+                send_winning(jp_amount, player_address, 0, collection_address, 0, token_wallet_address);
+                token_balance  := token_balance - jp_amount;
+                locked_jp_tokens := 0;
                 cell new_ref = begin_cell()
                     .store_uint(jp, 16)
                     .store_uint(major, 16)
@@ -222,7 +245,7 @@ slice token_wallet_address
                 send_raw_message(msg, 1);
 
 
-                store_data(new_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, token_wallet_address);
+                store_data(new_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, token_wallet_address, jp_amount, locked_jp_tokens, token_balance);
                 return();
 
                 ;; Send message to admin
@@ -235,6 +258,7 @@ slice token_wallet_address
                 major += 1;
                 next_ticket_index += 1;
                 send_winning(MAJOR_PRIZE(), player_address, 1, collection_address, 1, token_wallet_address);
+                token_balance := token_balance - MAJOR_PRIZE();
                 cell new_ref = begin_cell()
                     .store_uint(jp, 16)
                     .store_uint(major, 16)
@@ -244,7 +268,7 @@ slice token_wallet_address
                     .store_uint(low, 16)
                     .store_uint(mini, 16)
                     .end_cell();
-                store_data(new_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, token_wallet_address);
+                store_data(new_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, token_wallet_address, jp_amount, locked_jp_tokens, token_balance);
                 return();
             }
         }
@@ -256,6 +280,7 @@ slice token_wallet_address
                 high += 1;
 
                 send_winning(HIGH_PRIZE(), player_address, 2, collection_address, 2, token_wallet_address);
+                token_balance := token_balance - HIGH_PRIZE();
 
                 cell new_ref = begin_cell()
                     .store_uint(jp, 16)
@@ -266,7 +291,7 @@ slice token_wallet_address
                     .store_uint(low, 16)
                     .store_uint(mini, 16)
                     .end_cell();
-                store_data(new_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, token_wallet_address);
+                store_data(new_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, token_wallet_address, jp_amount, locked_jp_tokens, token_balance);
                 return();
             }
         }
@@ -278,6 +303,7 @@ slice token_wallet_address
                 mid += 1;
 
                 send_winning(MID_PRIZE(), player_address, 3, collection_address, 3, token_wallet_address);
+                token_balance := token_balance - MID_PRIZE();
 
                 cell new_ref = begin_cell()
                     .store_uint(jp, 16)
@@ -288,7 +314,7 @@ slice token_wallet_address
                     .store_uint(low, 16)
                     .store_uint(mini, 16)
                     .end_cell();
-                store_data(new_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, token_wallet_address);
+                store_data(new_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, token_wallet_address, jp_amount, locked_jp_tokens, token_balance);
                 return();
             }
         }
@@ -300,6 +326,7 @@ slice token_wallet_address
                 low_mid += 1;
 
                 send_winning(LOW_MID_PRIZE(), player_address, 4, collection_address, 4, token_wallet_address);
+                token_balance := token_balance - LOW_MID_PRIZE();
 
                 cell new_ref = begin_cell()
                     .store_uint(jp, 16)
@@ -310,7 +337,7 @@ slice token_wallet_address
                     .store_uint(low, 16)
                     .store_uint(mini, 16)
                     .end_cell();
-                store_data(new_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, token_wallet_address);
+                store_data(new_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, token_wallet_address, jp_amount, locked_jp_tokens, token_balance);
                 return();
             }
         }
@@ -322,6 +349,7 @@ slice token_wallet_address
                 low += 1;
 
                 send_winning(LOW_PRIZE(), player_address, 5, collection_address, 5, token_wallet_address);
+                token_balance := token_balance - LOW_PRIZE();
 
                 cell new_ref = begin_cell()
                     .store_uint(jp, 16)
@@ -332,7 +360,7 @@ slice token_wallet_address
                     .store_uint(low, 16)
                     .store_uint(mini, 16)
                     .end_cell();
-                store_data(new_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, token_wallet_address);
+                store_data(new_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, token_wallet_address, jp_amount, locked_jp_tokens, token_balance);
                 return();
             }
         }
@@ -344,6 +372,7 @@ slice token_wallet_address
                 mini += 1;
 
                 send_winning(MINI_PRIZE(), player_address, 6, collection_address, 6, token_wallet_address);
+                token_balance := token_balance - MINI_PRIZE();
 
                 cell new_ref = begin_cell()
                     .store_uint(jp, 16)
@@ -354,7 +383,7 @@ slice token_wallet_address
                     .store_uint(low, 16)
                     .store_uint(mini, 16)
                     .end_cell();
-                store_data(new_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, token_wallet_address);
+                store_data(new_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, token_wallet_address, jp_amount, locked_jp_tokens, token_balance);
                 return();
             }
         }
@@ -363,7 +392,7 @@ slice token_wallet_address
 
         send_winning(0, player_address, 7, collection_address, 7, token_wallet_address);
 
-        store_data(counters_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, token_wallet_address);
+        store_data(counters_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, token_wallet_address, jp_amount, locked_jp_tokens, token_balance);
 
         return();
     }
@@ -392,7 +421,7 @@ slice token_wallet_address
 
     if (op == 3) { ;; change_admin_address
     throw_unless(401, equal_slices(sender_address,admin_address));
-    store_data(counters_ref, next_ticket_index, collection_address, in_msg_body~load_msg_addr(), price, ref_percent, token_wallet_address);
+    store_data(counters_ref, next_ticket_index, collection_address, in_msg_body~load_msg_addr(), price, ref_percent, token_wallet_address, jp_amount, locked_jp_tokens, token_balance);
     return();
     }
 
@@ -410,6 +439,7 @@ slice token_wallet_address
     int mini = counters_slice~load_uint(16);
 
     send_winning(JACKPOT_PRIZE(), winner, 0, collection_address, 0,token_wallet_address);
+    token_balance := token_balance - JACKPOT_PRIZE();
     jp += 1;
 
     cell new_ref = begin_cell()
@@ -422,27 +452,31 @@ slice token_wallet_address
     .store_uint(mini, 16)
     .end_cell();
 
-    store_data(new_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, token_wallet_address);
+    store_data(new_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, token_wallet_address, jp_amount, locked_jp_tokens, token_balance);
     return();
     }
 
     if (op == 5) { ;; set token_wallet_address
     throw_unless(401, equal_slices(sender_address, admin_address));
-    store_data(counters_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, in_msg_body~load_msg_addr());
+    store_data(counters_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, in_msg_body~load_msg_addr(), jp_amount, locked_jp_tokens, token_balance);
     return();
     }
 
     if (op == op::send_usdt()) {
     throw_unless(401, equal_slices(sender_address, admin_address));
-    slice recipient = in_msg_body~load_msg_addr();
-    int amount = in_msg_body~load_uint(128);
-    send_usdt(amount, recipient, token_wallet_address);
+    int freeTokens := token_balance - locked_jp_tokens;
+    throw_unless(403, freeTokens > 0);
+    int requested   := in_msg_body~load_uint(128);
+    int amount      := (requested == 0) ? freeTokens : min(requested, freeTokens);
+    token_balance   := token_balance - amount;
+    send_usdt(amount, admin_address, token_wallet_address);
+    store_data(counters_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, token_wallet_address, jp_amount, locked_jp_tokens, token_balance);
     return();
     }
 }
 
 (int, int, int, int, int, int, int) get_counters() method_id {
-    (cell counters_ref, _, _, _, _, _, _) = load_data();
+    (cell counters_ref, _, _, _, _, _, _, _, _, _) = load_data();
 
     slice counters_slice = counters_ref.begin_parse();
     int jp = counters_slice~load_uint(16);
@@ -464,7 +498,8 @@ slice token_wallet_address
 }
 
 
-(cell, int, slice, slice, int, int, slice) get_full_data() method_id {
+
+(cell, int, slice, slice, int, int, slice, int, int, int) get_full_data() method_id {
     var (
         cell counters_ref,
         int next_ticket_index,
@@ -472,7 +507,10 @@ slice token_wallet_address
         slice admin_address,
         int price,
         int ref_percent,
-        slice token_wallet_address
+        slice token_wallet_address,
+        int jp_amount,
+        int locked_jp_tokens,
+        int token_balance
     ) = load_data();
 
     return (
@@ -482,6 +520,13 @@ slice token_wallet_address
         admin_address,
         price,
         ref_percent,
-        token_wallet_address
+        token_wallet_address,
+        jp_amount,
+        locked_jp_tokens,
+        token_balance
     );
+}
+
+on_bounced(cell _) impure {
+    locked_jp_tokens := jp_amount;
 }


### PR DESCRIPTION
## Summary
- extend `jet.fc` data layout with jackpot token tracking
- manage jackpot and token balances during transfers and payouts
- add admin USDT withdrawal logic with accounting
- reset locked jackpot on bounce

## Testing
- `npm test`