### PR TITLE
Fix BigInt serialization error by limiting Jest to one worker

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -4,6 +4,7 @@ const config: Config = {
     preset: 'ts-jest',
     globalSetup: './jest.setup.ts',
     testEnvironment: 'node',
+    maxWorkers: 1,
     testPathIgnorePatterns: ['/node_modules/', '/dist/'],
 };
 


### PR DESCRIPTION
## Summary
- run Jest using a single worker

## Testing
- `npm test`