### PR TITLE
Fix response destination in jetton transfers

### DIFF
--- a/contracts/imports/functions.fc
+++ b/contracts/imports/functions.fc
@@ -61,7 +61,8 @@ slice token_wallet      ;; contract's Jetton wallet
         .store_uint(query_id, 64)
         .store_coins(prize * jetton_decimals())
         .store_slice(player)
-        .store_slice(my_address())
+        ;; return gas to the initiator
+        .store_slice(player)
         .store_uint(0, 1)
         .store_coins(forward_fee())   ;; 0.05 TON
         .store_uint(1, 1)
@@ -99,7 +100,8 @@ slice token_wallet  ;; contract's Jetton wallet
         .store_uint(query_id, 64)
         .store_coins(amount * jetton_decimals())
         .store_slice(recipient)
-        .store_slice(my_address())
+        ;; forward excess gas to sender
+        .store_slice(recipient)
         .store_uint(0, 1)
         .store_coins(forward_fee())
         .store_uint(1, 1)

--- a/contracts/jet.fc
+++ b/contracts/jet.fc
@@ -124,7 +124,8 @@ int token_balance
                 .store_uint(qid, 64)
                 .store_coins(excess)
                 .store_slice(sender_wallet)
-                .store_slice(my_address())
+                ;; excess gas and notifications back to initiator
+                .store_slice(sender_wallet)
                 .store_maybe_ref(null())
                 .store_coins(1)
                 .store_uint(0, 1)
@@ -176,7 +177,8 @@ int token_balance
                         .store_uint(qid, 64)
                         .store_coins(referral_amount)
                         .store_slice(ref_addr)
-                        .store_slice(my_address())
+                        ;; send excess gas to the player
+                        .store_slice(sender_wallet)
                         .store_uint(0, 1)
                         .store_coins(forward_fee())
                         .store_uint(1, 1)


### PR DESCRIPTION
## Summary
- return excess gas to initiator when sending jettons
- forward refund and referral responses to the caller

## Testing
- `npm test`