### PR TITLE
Fix missing end_parse call

### DIFF
--- a/contracts/jet.fc
+++ b/contracts/jet.fc
@@ -158,6 +158,8 @@ int token_balance
                 has_ref = 1;
             }
         }
+        ;; ensure payload has no extra bits
+        end_parse(fwd_payload);
 
         if (has_ref) {
 


### PR DESCRIPTION
## Summary
- ensure forward payload slice fully consumed

## Testing
- `npm test`