### PR TITLE
Fix handling of unknown operation codes

### DIFF
--- a/contracts/jet.fc
+++ b/contracts/jet.fc
@@ -489,6 +489,7 @@ int token_balance
     store_data(counters_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, token_wallet_address, jp_amount, locked_jp_tokens, token_balance);
     return();
     }
+    throw(0xffff);
 }
 
 (int, int, int, int, int, int, int) get_counters() method_id {


### PR DESCRIPTION
## Summary
- reject unrecognized op codes in `jet.fc`

## Testing
- `npm test --silent`