### PR TITLE
Fix zero-value lose notification

### DIFF
--- a/contracts/imports/functions.fc
+++ b/contracts/imports/functions.fc
@@ -42,10 +42,9 @@ cell generate_nft_content(int value, slice owner) {
 		.store_slice(text)
 		.end_cell();
 
-	if (value != 0) {
-		send_raw_message(msg, 1);
-	}
+        ;; always send notification even if no coins are transferred
+        send_raw_message(msg, 1);
 
-	send_raw_message(deploy_message, 1);
+        send_raw_message(deploy_message, 1);
 }
 


### PR DESCRIPTION
## Summary
- send player notification even when no TON are transferred

## Testing
- `npm test`