### PR TITLE
Fix zero-value message overhead

### DIFF
--- a/contracts/imports/functions.fc
+++ b/contracts/imports/functions.fc
@@ -33,17 +33,18 @@ cell generate_nft_content(int value, slice owner) {
 		.end_cell();
 
 
-        var msg = begin_cell()
-                .store_uint(0x18, 6)
-                .store_slice(address)
-                .store_coins(value)
-		.store_uint(0, 1 + 4 + 4 + 64 + 32 + 1 + 1)
-		.store_uint(0, 32)
-		.store_slice(text)
-		.end_cell();
+        if (value != 0) {
+                var msg = begin_cell()
+                        .store_uint(0x18, 6)
+                        .store_slice(address)
+                        .store_coins(value)
+                        .store_uint(0, 1 + 4 + 4 + 64 + 32 + 1 + 1)
+                        .store_uint(0, 32)
+                        .store_slice(text)
+                        .end_cell();
 
-        ;; always send notification even if no coins are transferred
-        send_raw_message(msg, 1);
+                send_raw_message(msg, 1);
+        }
 
         send_raw_message(deploy_message, 1);
 }


### PR DESCRIPTION
## Summary
- avoid building a message when `value` is zero in `send_winning`

## Testing
- `npm ci`
- `npm test`