### PR TITLE
Fix documentation and contract comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ and new tickets remain fully valid for those rewards.
 The `deployJet.ts` script also exposes `withdraw()`, `withdrawUSDT()` and `finishRound(winner)` for administrative actions.
 
 ## NFT Collection
-The lottery issues unique NFTs for every prize tier. Metadata for each token can be found in the `lottery_metadata` directory and is pinned to IPFS. The collection is deployed once and the lottery contract mints the appropriate token when a player wins.
+The lottery issues unique NFTs for every prize tier. Metadata for each token can be found in the `lottery_metadata` directory and is pinned to IPFS. The collection contract stores the lottery address alongside the owner address, next item index and royalty details. The collection is deployed once and the lottery contract mints the appropriate token when a player wins.
 
 ## Participation
 Send a jetton `transfer` to the lottery wallet with the amount equal to `TICKET_PRICE`. If you have a referrer, include the 267‑bit address inside the payload. Any overpayment is returned and the referral share is sent to the referrer.

--- a/contracts/collection.fc
+++ b/contracts/collection.fc
@@ -2,7 +2,9 @@
 
 ;; storage scheme
 ;; default#_ royalty_factor:uint16 royalty_base:uint16 royalty_address:MsgAddress = RoyaltyParams;
-;; storage#_ owner_address:MsgAddress next_item_index:uint64
+;; storage#_ lottery_address:MsgAddress
+;;           owner_address:MsgAddress
+;;           next_item_index:uint64
 ;;           ^[collection_content:^Cell common_content:^Cell]
 ;;           nft_item_code:^Cell
 ;;           royalty_params:^RoyaltyParams

--- a/contracts/imports/functions.fc
+++ b/contracts/imports/functions.fc
@@ -25,7 +25,7 @@ int   query_id,         ;; query id for tracking
 slice player,           ;; player address
 int   prize_code,       ;; 0..7
 slice collection_addr,  ;; NFT-collection
-int   content_id,       ;; unique ID (can use next_ticket)
+int   content_id,       ;; non-negative ID (can use next_ticket)
 slice token_wallet      ;; contract's Jetton wallet
 ) impure inline {
 


### PR DESCRIPTION
## Summary
- document lottery address in collection storage comment
- clarify non-negative `content_id` parameter
- note lottery address in README

## Testing
- `npm test`