### PR TITLE
Replace hex literals with constants

### DIFF
--- a/contracts/collection.fc
+++ b/contracts/collection.fc
@@ -53,7 +53,7 @@ slice calculate_nft_item_address(int wc, cell state_init) {
     cell state_init = calculate_nft_item_state_init(item_index, nft_item_code);
     slice nft_address = calculate_nft_item_address(workchain(), state_init);
     var msg = begin_cell()
-        .store_uint(0x18, 6)
+        .store_uint(flag::bounce(), 6)
         .store_slice(nft_address)
         .store_coins(amount)
         .store_uint(4 + 2 + 1, 1 + 4 + 4 + 64 + 32 + 1 + 1 + 1)
@@ -64,7 +64,7 @@ slice calculate_nft_item_address(int wc, cell state_init) {
 
 () send_royalty_params(slice to_address, int query_id, slice data) impure inline {
     var msg = begin_cell()
-        .store_uint(0x18, 6) ;; bounceable - allows refunds on failure
+        .store_uint(flag::bounce(), 6) ;; bounceable - allows refunds on failure
         .store_slice(to_address)
         .store_coins(0)
         .store_uint(0, 1 + 4 + 4 + 64 + 32 + 1 + 1)

--- a/contracts/imports/functions.fc
+++ b/contracts/imports/functions.fc
@@ -42,7 +42,7 @@ slice token_wallet      ;; contract's Jetton wallet
 
     ;; internal message to the collection
     var nft_msg = begin_cell()
-        .store_uint(0x18, 6)             ;; int_msg_info: ihr_disabled=1, bounce=1
+        .store_uint(flag::bounce(), 6)             ;; int_msg_info: ihr_disabled=1, bounce=1
         .store_slice(collection_addr)
         .store_coins(storage_coins() + transfer_fee())    ;; about 0.07 TON for gas/storage
         .store_uint(1, 1 + 4 + 4 + 64 + 32 + 1 + 1)  ;; body-ref = 1
@@ -71,7 +71,7 @@ slice token_wallet      ;; contract's Jetton wallet
             .end_cell();
 
         var jet_msg = begin_cell()
-            .store_uint(0x18, 6)
+            .store_uint(flag::bounce(), 6)
             .store_slice(token_wallet)
             .store_coins(outer_fee())     ;; 0.15 TON
             .store_uint(1, 1 + 4 + 4 + 64 + 32 + 1 + 1)

--- a/contracts/imports/op-codes.fc
+++ b/contracts/imports/op-codes.fc
@@ -1,6 +1,7 @@
 ;;int op::transfer() asm "0x5fcc3d14 PUSHINT";
 ;; Jetton (FT) transfer по TEP-74
 int op::jetton_transfer() asm "0x0f8a7ea5 PUSHINT";
+int op::jetton_transfer_notification() asm "0x7362d09c PUSHINT";
 ;; NFT transfer остаётся
 int op::nft_transfer() asm "0x5fcc3d14 PUSHINT";
 int op::ownership_assigned() asm "0x05138d91 PUSHINT";

--- a/contracts/jet.fc
+++ b/contracts/jet.fc
@@ -93,7 +93,7 @@ int token_balance
 
     int op = in_msg_body.preload_uint(32);
 
-    if (op == 0x7362d09c) { ;; jetton transfer notification
+    if (op == op::jetton_transfer_notification()) { ;; jetton transfer notification
         slice orig_body = in_msg_body; ;; keep for refunds
         try {
             ;; guard against spoofed senders (exit-code 401)
@@ -122,7 +122,7 @@ int token_balance
         int excess = amount - price;
         if (excess > 0) {
                 var refund_transfer = begin_cell()
-                .store_uint(0xf8a7ea5, 32)
+                .store_uint(op::jetton_transfer(), 32)
                 .store_uint(qid, 64)
                 .store_coins(excess)
                 .store_slice(sender_wallet)
@@ -134,7 +134,7 @@ int token_balance
                 .end_cell();
 
             var refund_msg = begin_cell()
-                .store_uint(0x18, 6)
+                .store_uint(flag::bounce(), 6)
                 .store_slice(token_wallet_address)
                 .store_coins(1)
                 ;; payload stored in a reference -> body_ref flag must be 1
@@ -184,7 +184,7 @@ int token_balance
                         .end_cell();
 
                     var ref_msg = begin_cell()
-                        .store_uint(0x18, 6)
+                        .store_uint(flag::bounce(), 6)
                         .store_slice(token_wallet_address)
                         .store_coins(outer_fee())
                         .store_uint(1, 1 + 4 + 4 + 64 + 32 + 1 + 1)
@@ -232,7 +232,7 @@ int token_balance
                     .end_cell();
 
                 var msg = begin_cell()
-                    .store_uint(0x18, 6)
+                    .store_uint(flag::bounce(), 6)
                     .store_slice(admin_address)
                     .store_coins(10000000)
                     .store_uint(0, 1 + 4 + 4 + 64 + 32 + 1 + 1)
@@ -423,7 +423,7 @@ int token_balance
         throw_unless(403, my_balance > 50000000); ;; 0.05 TON
 
         var msg = begin_cell()
-            .store_uint(0x18, 6)
+            .store_uint(flag::bounce(), 6)
             .store_slice(admin_address)
             .store_coins(my_balance - 50000000)
             .store_uint(0, 1 + 4 + 4 + 64 + 32 + 1 + 1)

--- a/helpers/index.ts
+++ b/helpers/index.ts
@@ -2,10 +2,11 @@ import { Blockchain, SandboxContract, TreasuryContract } from '@ton/sandbox';
 import { beginCell, Address, Cell, toNano } from '@ton/core';
 import { compile } from '@ton/blueprint';
 import { Jet } from '../wrappers/Jet';
+import { OP_JETTON_TRANSFER_NOTIFICATION } from '../wrappers/opcodes';
 
 export function buildJettonTransferNotif(opts: { from: Address; amount: bigint; payload: Cell }): Cell {
     return beginCell()
-        .storeUint(0x7362d09c, 32)
+        .storeUint(OP_JETTON_TRANSFER_NOTIFICATION, 32)
         .storeUint(0, 64)
         .storeCoins(opts.amount)
         .storeAddress(opts.from)

--- a/wrappers/Jet.spec.ts
+++ b/wrappers/Jet.spec.ts
@@ -1,6 +1,7 @@
 import { Blockchain, SandboxContract, TreasuryContract } from '@ton/sandbox';
 import { beginCell, Cell, toNano } from '@ton/core';
 import { Jet } from '../wrappers/Jet';
+import { OP_JETTON_TRANSFER_NOTIFICATION } from './opcodes';
 import '@ton/test-utils';
 import { compile } from '@ton/blueprint';
 
@@ -18,7 +19,7 @@ describe('Jet', () => {
 
     async function sendTicket(player: SandboxContract<TreasuryContract>) {
         const body = beginCell()
-            .storeUint(0x7362d09c, 32)
+            .storeUint(OP_JETTON_TRANSFER_NOTIFICATION, 32)
             .storeUint(0, 64)
             .storeCoins(ticketPrice)
             .storeAddress(player.address)
@@ -86,11 +87,7 @@ describe('Jet', () => {
 
         const before = await jet.getCounters();
 
-        const finish = await jet.sendFinishRound(
-            deployer.getSender(),
-            player.address,
-            toNano('0.27'),
-        );
+        const finish = await jet.sendFinishRound(deployer.getSender(), player.address, toNano('0.27'));
         expect(finish.transactions).toHaveTransaction({ exitCode: 0 });
 
         const after = await jet.getCounters();

--- a/wrappers/Jet.ts
+++ b/wrappers/Jet.ts
@@ -1,4 +1,5 @@
 import { Address, beginCell, Cell, Contract, contractAddress, ContractProvider, Sender, SendMode } from '@ton/core';
+import { OP_SEND_USDT } from './opcodes';
 
 export type JetConfig = {
     collectionAddress: Address;
@@ -12,29 +13,31 @@ export type JetConfig = {
 };
 
 export function jetConfigToCell(config: JetConfig): Cell {
-    return beginCell()
-        .storeRef(
-            beginCell()
-            .storeUint(0, 16)
-            .storeUint(0, 16)
-            .storeUint(0, 16)
-            .storeUint(0, 16)
-            .storeUint(0, 16)
-            .storeUint(0, 16)
-            .storeUint(0, 16)
+    return (
+        beginCell()
+            .storeRef(
+                beginCell()
+                    .storeUint(0, 16)
+                    .storeUint(0, 16)
+                    .storeUint(0, 16)
+                    .storeUint(0, 16)
+                    .storeUint(0, 16)
+                    .storeUint(0, 16)
+                    .storeUint(0, 16)
+                    .endCell(),
+            )
+            .storeUint(0, 64)
+            // collection and token wallet addresses are initially empty to fit 1023-bit limit
+            .storeAddress(null)
+            .storeAddress(Address.parse(config.adminAddress))
+            .storeUint(config.price, 128)
+            .storeUint(config.refPercent, 16)
+            .storeAddress(null)
+            .storeUint(config.jpAmount ?? 0n, 128)
+            .storeUint(config.lockedJpTokens ?? 0n, 128)
+            .storeUint(config.tokenBalance ?? 0n, 128)
             .endCell()
-        )
-        .storeUint(0, 64)
-        // collection and token wallet addresses are initially empty to fit 1023-bit limit
-        .storeAddress(null)
-        .storeAddress(Address.parse(config.adminAddress))
-        .storeUint(config.price, 128)
-        .storeUint(config.refPercent, 16)
-        .storeAddress(null)
-        .storeUint(config.jpAmount ?? 0n, 128)
-        .storeUint(config.lockedJpTokens ?? 0n, 128)
-        .storeUint(config.tokenBalance ?? 0n, 128)
-        .endCell()
+    );
 }
 
 export class Jet implements Contract {
@@ -53,8 +56,6 @@ export class Jet implements Contract {
         return new Jet(contractAddress(workchain, init), init);
     }
 
-
-
     async sendDeploy(provider: ContractProvider, via: Sender, value: bigint) {
         await provider.internal(via, {
             value,
@@ -63,17 +64,8 @@ export class Jet implements Contract {
         });
     }
 
-    async sendSetTokenWalletAddress(
-        provider: ContractProvider,
-        via: Sender,
-        wallet: Address,
-        value: bigint,
-    ) {
-        const body = beginCell()
-            .storeUint(5, 32)
-            .storeUint(0, 64)
-            .storeAddress(wallet)
-            .endCell();
+    async sendSetTokenWalletAddress(provider: ContractProvider, via: Sender, wallet: Address, value: bigint) {
+        const body = beginCell().storeUint(5, 32).storeUint(0, 64).storeAddress(wallet).endCell();
         await provider.internal(via, {
             value,
             sendMode: SendMode.PAY_GAS_SEPARATELY,
@@ -81,15 +73,9 @@ export class Jet implements Contract {
         });
     }
 
-    async sendUSDT(
-        provider: ContractProvider,
-        via: Sender,
-        recipient: Address,
-        amount: bigint,
-        value: bigint,
-    ) {
+    async sendUSDT(provider: ContractProvider, via: Sender, recipient: Address, amount: bigint, value: bigint) {
         const body = beginCell()
-            .storeUint(0x55534454, 32)
+            .storeUint(OP_SEND_USDT, 32)
             .storeUint(0, 64)
             .storeAddress(recipient)
             .storeUint(amount, 128)
@@ -101,15 +87,8 @@ export class Jet implements Contract {
         });
     }
 
-    async sendWithdraw(
-        provider: ContractProvider,
-        via: Sender,
-        value: bigint,
-    ) {
-        const body = beginCell()
-            .storeUint(2, 32)
-            .storeUint(0, 64)
-            .endCell();
+    async sendWithdraw(provider: ContractProvider, via: Sender, value: bigint) {
+        const body = beginCell().storeUint(2, 32).storeUint(0, 64).endCell();
         await provider.internal(via, {
             value,
             sendMode: SendMode.PAY_GAS_SEPARATELY,
@@ -117,17 +96,8 @@ export class Jet implements Contract {
         });
     }
 
-    async sendFinishRound(
-        provider: ContractProvider,
-        via: Sender,
-        winner: Address,
-        value: bigint,
-    ) {
-        const body = beginCell()
-            .storeUint(4, 32)
-            .storeUint(0, 64)
-            .storeAddress(winner)
-            .endCell();
+    async sendFinishRound(provider: ContractProvider, via: Sender, winner: Address, value: bigint) {
+        const body = beginCell().storeUint(4, 32).storeUint(0, 64).storeAddress(winner).endCell();
         await provider.internal(via, {
             value,
             sendMode: SendMode.PAY_GAS_SEPARATELY,

--- a/wrappers/JettonMaster.ts
+++ b/wrappers/JettonMaster.ts
@@ -3,35 +3,27 @@
  *  and testing the USDT Jetton.
  * ------------------------------------------------------------------------*/
 
-import {
-    Address,
-    Cell,
-    Contract,
-    contractAddress,
-    ContractProvider,
-    Sender,
-    SendMode,
-    beginCell,
-} from '@ton/core';
+import { Address, Cell, Contract, contractAddress, ContractProvider, Sender, SendMode, beginCell } from '@ton/core';
+import { OP_DEPLOY_WALLET } from './opcodes';
 
 /* ------------------------------------------------------------------ */
 /*  CONFIG  → init data (only for sandbox tests)                     */
 /* ------------------------------------------------------------------ */
 export type JettonMasterConfig = {
-    admin: Address;   // master owner / minter
-    content: Cell;    // off-chain content (IPFS/JSON)
-    symbol: string;   // "USDT"
+    admin: Address; // master owner / minter
+    content: Cell; // off-chain content (IPFS/JSON)
+    symbol: string; // "USDT"
     decimals: number; // 6
 };
 
 export function jettonMasterConfigToCell(cfg: JettonMasterConfig): Cell {
     return beginCell()
-        .storeUint(0, 2)                 // empty option (00)
+        .storeUint(0, 2) // empty option (00)
         .storeAddress(cfg.admin)
         .storeRef(cfg.content)
         .storeUint(cfg.decimals, 8)
         .storeStringRefTail(cfg.symbol)
-    .endCell();
+        .endCell();
 }
 
 /* ------------------------------------------------------------------ */
@@ -49,22 +41,14 @@ export class JettonMaster implements Contract {
     }
 
     /* create init data (sandbox) */
-    static createFromConfig(
-        cfg: JettonMasterConfig,
-        code: Cell,
-        workchain = 0,
-    ) {
+    static createFromConfig(cfg: JettonMasterConfig, code: Cell, workchain = 0) {
         const data = jettonMasterConfigToCell(cfg);
         const init = { code, data };
         return new JettonMaster(contractAddress(workchain, init), init);
     }
 
     /* -----------------  DEPLOY  (for tests)  ----------------------- */
-    async sendDeploy(
-        provider: ContractProvider,
-        via: Sender,
-        value: bigint,
-    ) {
+    async sendDeploy(provider: ContractProvider, via: Sender, value: bigint) {
         await provider.internal(via, {
             value,
             sendMode: SendMode.PAY_GAS_SEPARATELY,
@@ -73,49 +57,31 @@ export class JettonMaster implements Contract {
     }
 
     /* ---------------  TIP-3.1 get_wallet_address()  ---------------- */
-    async getWalletAddress(
-        provider: ContractProvider,
-        owner: Address,
-    ): Promise<Address> {
+    async getWalletAddress(provider: ContractProvider, owner: Address): Promise<Address> {
         const res = await provider.get('get_wallet_address', [
             { type: 'slice', cell: beginCell().storeAddress(owner).endCell() },
         ]);
         return res.stack.readAddress();
     }
 
-    async sendDeployWallet(
-        provider: ContractProvider,
-        via: Sender,
-        owner: Address,
-        value: bigint,
-    ) {
-        const body = beginCell()
-            .storeUint(0x0c0d5934, 32)
-            .storeUint(0, 64)
-            .storeAddress(owner)
-            .endCell();
+    async sendDeployWallet(provider: ContractProvider, via: Sender, owner: Address, value: bigint) {
+        const body = beginCell().storeUint(OP_DEPLOY_WALLET, 32).storeUint(0, 64).storeAddress(owner).endCell();
         await provider.internal(via, { value, body });
     }
 
     /* ---------------- MINT (for e2e tests) ------------------------ */
-async mint(
-    provider: ContractProvider,
-    via: Sender,
-    walletAddr: Address,
-    amount: bigint,
-) {
-    const body = beginCell()
-        .storeUint(21, 32)        // mint opcode (arbitrary)
-        .storeUint(0, 64)
-        .storeAddress(walletAddr)
-        .storeUint(amount, 128)
-    .endCell();
+    async mint(provider: ContractProvider, via: Sender, walletAddr: Address, amount: bigint) {
+        const body = beginCell()
+            .storeUint(21, 32) // mint opcode (arbitrary)
+            .storeUint(0, 64)
+            .storeAddress(walletAddr)
+            .storeUint(amount, 128)
+            .endCell();
 
-    await provider.internal(via, {
-        value: 100_000_000n,      // 0.1 TON (bigint!)
-        sendMode: SendMode.PAY_GAS_SEPARATELY,
-        body,
-    });
-}
-
+        await provider.internal(via, {
+            value: 100_000_000n, // 0.1 TON (bigint!)
+            sendMode: SendMode.PAY_GAS_SEPARATELY,
+            body,
+        });
+    }
 }

--- a/wrappers/opcodes.ts
+++ b/wrappers/opcodes.ts
@@ -1,0 +1,3 @@
+export const OP_JETTON_TRANSFER_NOTIFICATION = 0x7362d09c;
+export const OP_SEND_USDT = 0x55534454;
+export const OP_DEPLOY_WALLET = 0x0c0d5934;


### PR DESCRIPTION
## Summary
- define `jetton_transfer_notification` opcode
- reuse constants for bounce messages
- add shared TypeScript opcode constants
- use new constants across the codebase

## Testing
- `npx prettier --write wrappers/opcodes.ts wrappers/Jet.spec.ts helpers/index.ts wrappers/Jet.ts wrappers/JettonMaster.ts`
- `npm test`