### PR TITLE
feat(usdt): add timelock for USDT withdrawals

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,7 @@ TICKET_PRICE=10000000 # 10 tokens with 9 decimals
 # Jackpot amount for USDT lottery (whole USDT)
 JACKPOT_AMOUNT_USDT=10000
 
+# Timelock delay for USDT withdrawals (seconds)
+# default: 172800 on mainnet, 3600 on testnet
+TIMELOCK_DELAY_SEC=172800
+

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ and new tickets remain fully valid for those rewards.
    - `REF_PERCENT` – referral payout in basis points.
    - `JACKPOT_AMOUNT_USDT` – jackpot size (whole USDT) for the USDT lottery
      (defaults: 10 000 mainnet / 100 testnet).
+   - `TIMELOCK_DELAY_SEC` – timelock delay (in seconds) for USDT withdrawals  
+     (defaults: 172 800 s on mainnet, 3 600 s on testnet).
 
 ## Deployment
 1. Prepare the metadata files `collection.json` and `0.json–7.json`, upload them to IPFS and place the resulting link into `collectionConfig.content`.

--- a/contracts/jet.fc
+++ b/contracts/jet.fc
@@ -2,6 +2,7 @@
 #include "imports/functions.fc";
 
 ;; Jackpot is paid automatically; no admin trigger exists.
+;; USDT withdrawals use timelock (op 6/7), TON withdrawals are instant.
 
 int JACKPOT_PRIZE() asm "10000 PUSHINT"; ;; 10,000 tokens
 int MAJOR_PRIZE() asm "1800 PUSHINT";    ;; 1,800 tokens
@@ -10,6 +11,9 @@ int MID_PRIZE() asm "180 PUSHINT";       ;; 180 tokens
 int LOW_MID_PRIZE() asm "50 PUSHINT";    ;; 50 tokens
 int LOW_PRIZE() asm "25 PUSHINT";        ;; 25 tokens
 int MINI_PRIZE() asm "10 PUSHINT";       ;; 10 tokens
+
+const int OP_SCHEDULE_USDT = 6;
+const int OP_EXEC_USDT     = 7;
 
 (
     cell, ;; counters
@@ -21,7 +25,10 @@ int MINI_PRIZE() asm "10 PUSHINT";       ;; 10 tokens
     slice, ;; token_wallet_address
     int,   ;; jp_amount
     int,   ;; locked_jp_tokens
-    int    ;; token_balance
+    int,   ;; token_balance
+    int,   ;; tl_usdt_amount
+    int,   ;; tl_usdt_until
+    int    ;; tl_delay
 ) load_data() inline {
     var ds = get_data().begin_parse();
     return (
@@ -34,7 +41,9 @@ int MINI_PRIZE() asm "10 PUSHINT";       ;; 10 tokens
         ds~load_msg_addr(),
         ds~load_uint(128),
         ds~load_uint(128),
-        ds~load_uint(128)
+        ds~load_uint(128),
+        ds~load_uint(64),
+        ds~load_uint(64)
     );
 }
 
@@ -48,7 +57,10 @@ int ref_percent,
 slice token_wallet_address,
 int jp_amount,
 int locked_jp_tokens,
-int token_balance
+    int token_balance,
+    int tl_usdt_amount,
+    int tl_usdt_until,
+    int tl_delay
 ) impure inline {
     set_data(
         begin_cell()
@@ -62,6 +74,9 @@ int token_balance
             .store_uint(jp_amount, 128)
             .store_uint(locked_jp_tokens, 128)
             .store_uint(token_balance, 128)
+            .store_uint(tl_usdt_amount, 128)
+            .store_uint(tl_usdt_until, 64)
+            .store_uint(tl_delay, 64)
             .end_cell()
     );
 }
@@ -90,7 +105,10 @@ int token_balance
         slice token_wallet_address,
         int jp_amount,
         int locked_jp_tokens,
-        int token_balance
+        int token_balance,
+        int tl_usdt_amount,
+        int tl_usdt_until,
+        int tl_delay
     ) = load_data();
 
     int op = in_msg_body.preload_uint(32);
@@ -241,7 +259,7 @@ int token_balance
                 store_data(new_ref, next_ticket_index, collection_address,
                            admin_address, price, ref_percent,
                            token_wallet_address, jp_amount, locked_jp_tokens,
-                           token_balance);
+                           token_balance, tl_usdt_amount, tl_usdt_until, tl_delay);
                 return ();
             }
         }
@@ -262,7 +280,7 @@ int token_balance
                     .store_uint(low, 16)
                     .store_uint(mini, 16)
                     .end_cell();
-                store_data(new_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, token_wallet_address, jp_amount, locked_jp_tokens, token_balance);
+                store_data(new_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, token_wallet_address, jp_amount, locked_jp_tokens, token_balance, tl_usdt_amount, tl_usdt_until, tl_delay);
                 return();
             }
         }
@@ -285,7 +303,7 @@ int token_balance
                     .store_uint(low, 16)
                     .store_uint(mini, 16)
                     .end_cell();
-                store_data(new_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, token_wallet_address, jp_amount, locked_jp_tokens, token_balance);
+                store_data(new_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, token_wallet_address, jp_amount, locked_jp_tokens, token_balance, tl_usdt_amount, tl_usdt_until, tl_delay);
                 return();
             }
         }
@@ -308,7 +326,7 @@ int token_balance
                     .store_uint(low, 16)
                     .store_uint(mini, 16)
                     .end_cell();
-                store_data(new_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, token_wallet_address, jp_amount, locked_jp_tokens, token_balance);
+                store_data(new_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, token_wallet_address, jp_amount, locked_jp_tokens, token_balance, tl_usdt_amount, tl_usdt_until, tl_delay);
                 return();
             }
         }
@@ -331,7 +349,7 @@ int token_balance
                     .store_uint(low, 16)
                     .store_uint(mini, 16)
                     .end_cell();
-                store_data(new_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, token_wallet_address, jp_amount, locked_jp_tokens, token_balance);
+                store_data(new_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, token_wallet_address, jp_amount, locked_jp_tokens, token_balance, tl_usdt_amount, tl_usdt_until, tl_delay);
                 return();
             }
         }
@@ -354,7 +372,7 @@ int token_balance
                     .store_uint(low, 16)
                     .store_uint(mini, 16)
                     .end_cell();
-                store_data(new_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, token_wallet_address, jp_amount, locked_jp_tokens, token_balance);
+                store_data(new_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, token_wallet_address, jp_amount, locked_jp_tokens, token_balance, tl_usdt_amount, tl_usdt_until, tl_delay);
                 return();
             }
         }
@@ -377,7 +395,7 @@ int token_balance
                     .store_uint(low, 16)
                     .store_uint(mini, 16)
                     .end_cell();
-                store_data(new_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, token_wallet_address, jp_amount, locked_jp_tokens, token_balance);
+                store_data(new_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, token_wallet_address, jp_amount, locked_jp_tokens, token_balance, tl_usdt_amount, tl_usdt_until, tl_delay);
                 return();
             }
         }
@@ -386,7 +404,7 @@ int token_balance
 
         send_winning(0, qid, player_address, 7, collection_address, 7, token_wallet_address);
 
-        store_data(counters_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, token_wallet_address, jp_amount, locked_jp_tokens, token_balance);
+        store_data(counters_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, token_wallet_address, jp_amount, locked_jp_tokens, token_balance, tl_usdt_amount, tl_usdt_until, tl_delay);
 
         return();
         }
@@ -413,6 +431,48 @@ int token_balance
     in_msg_body~load_uint(32);
     int qid = in_msg_body~load_uint(64);
 
+    if (op == OP_SCHEDULE_USDT) {
+        throw_unless(401, equal_slices(sender_address, admin_address));
+
+        int freeTokens = token_balance - locked_jp_tokens;
+        int req        = in_msg_body~load_uint(128);
+
+        throw_unless(403, req <= freeTokens);
+
+        if (req == 0) {
+            tl_usdt_amount := 0;
+            tl_usdt_until  := 0;
+        } else {
+            tl_usdt_amount := req;
+            tl_usdt_until  := now() + tl_delay;
+        }
+
+        store_data(counters_ref, next_ticket_index, collection_address,
+                   admin_address, price, ref_percent,
+                   token_wallet_address, jp_amount, locked_jp_tokens,
+                   token_balance, tl_usdt_amount, tl_usdt_until, tl_delay);
+        return ();
+    }
+
+    if (op == OP_EXEC_USDT) {
+        throw_unless(403, now()  >= tl_usdt_until);
+        throw_unless(403, tl_usdt_amount > 0);
+
+        int freeTokens = token_balance - locked_jp_tokens;
+        throw_unless(402, tl_usdt_amount <= freeTokens);
+
+        send_usdt(tl_usdt_amount, qid, admin_address, token_wallet_address);
+        token_balance   := token_balance - tl_usdt_amount;
+        tl_usdt_amount  := 0;
+        tl_usdt_until   := 0;
+
+        store_data(counters_ref, next_ticket_index, collection_address,
+                   admin_address, price, ref_percent,
+                   token_wallet_address, jp_amount, locked_jp_tokens,
+                   token_balance, tl_usdt_amount, tl_usdt_until, tl_delay);
+        return ();
+    }
+
     if (op == 2) { ;; withdrawal
         throw_unless(401, equal_slices(sender_address, admin_address));
         throw_unless(403, my_balance > 50000000); ;; 0.05 TON
@@ -432,14 +492,14 @@ int token_balance
 
     if (op == 3) { ;; change_admin_address
     throw_unless(401, equal_slices(sender_address,admin_address));
-    store_data(counters_ref, next_ticket_index, collection_address, in_msg_body~load_msg_addr(), price, ref_percent, token_wallet_address, jp_amount, locked_jp_tokens, token_balance);
+    store_data(counters_ref, next_ticket_index, collection_address, in_msg_body~load_msg_addr(), price, ref_percent, token_wallet_address, jp_amount, locked_jp_tokens, token_balance, tl_usdt_amount, tl_usdt_until, tl_delay);
     return();
     }
 
 
     if (op == 5) { ;; set token_wallet_address
     throw_unless(401, equal_slices(sender_address, admin_address));
-    store_data(counters_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, in_msg_body~load_msg_addr(), jp_amount, locked_jp_tokens, token_balance);
+    store_data(counters_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, in_msg_body~load_msg_addr(), jp_amount, locked_jp_tokens, token_balance, tl_usdt_amount, tl_usdt_until, tl_delay);
     return();
     }
 
@@ -451,14 +511,14 @@ int token_balance
     int amount      = (requested == 0) ? freeTokens : min(requested, freeTokens);
     token_balance   = token_balance - amount;
     send_usdt(amount, qid, admin_address, token_wallet_address);
-    store_data(counters_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, token_wallet_address, jp_amount, locked_jp_tokens, token_balance);
+    store_data(counters_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, token_wallet_address, jp_amount, locked_jp_tokens, token_balance, tl_usdt_amount, tl_usdt_until, tl_delay);
     return();
     }
     throw(0xffff);
 }
 
 (int, int, int, int, int, int, int) get_counters() method_id {
-    (cell counters_ref, _, _, _, _, _, _, _, _, _) = load_data();
+    (cell counters_ref, _, _, _, _, _, _, _, _, _, _, _, _) = load_data();
 
     slice counters_slice = counters_ref.begin_parse();
     int jp = counters_slice~load_uint(16);
@@ -492,7 +552,10 @@ int token_balance
         slice token_wallet_address,
         int jp_amount,
         int locked_jp_tokens,
-        int token_balance
+        int token_balance,
+        int tl_usdt_amount,
+        int tl_usdt_until,
+        int tl_delay
     ) = load_data();
 
     return (
@@ -505,7 +568,10 @@ int token_balance
         token_wallet_address,
         jp_amount,
         locked_jp_tokens,
-        token_balance
+        token_balance,
+        tl_usdt_amount,
+        tl_usdt_until,
+        tl_delay
     );
 }
 
@@ -520,10 +586,13 @@ int token_balance
         slice token_wallet_address,
         int jp_amount,
         int locked_jp_tokens,
-        int token_balance
+        int token_balance,
+        int tl_usdt_amount,
+        int tl_usdt_until,
+        int tl_delay
     ) = load_data();
 
     locked_jp_tokens = jp_amount;
 
-    store_data(counters_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, token_wallet_address, jp_amount, locked_jp_tokens, token_balance);
+    store_data(counters_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, token_wallet_address, jp_amount, locked_jp_tokens, token_balance, tl_usdt_amount, tl_usdt_until, tl_delay);
 }

--- a/scripts/deployJet.ts
+++ b/scripts/deployJet.ts
@@ -33,6 +33,11 @@ export async function run(provider: NetworkProvider) {
         ? BigInt(process.env.JACKPOT_AMOUNT_USDT) * 10n ** 9n
         : (network === 'mainnet' ? 10_000n : 100n) * 10n ** 9n;
 
+    // timelock delay (seconds)
+    const tlDelay = process.env.TIMELOCK_DELAY_SEC
+        ? BigInt(process.env.TIMELOCK_DELAY_SEC)
+        : (network === 'mainnet' ? 172800n : 3600n);   // 48h / 1h
+
     const stateInit = beginCell()
         .storeRef(
             beginCell()
@@ -54,6 +59,9 @@ export async function run(provider: NetworkProvider) {
         .storeUint(jpUsdt, 128)   // jp_amount
         .storeUint(0n, 128)       // locked_jp_tokens
         .storeUint(0n, 128)       // token_balance
+        .storeUint(0n, 128)       // tl_usdt_amount
+        .storeUint(0n, 64)        // tl_usdt_until
+        .storeUint(tlDelay, 64)   // tl_delay
         .endCell();
 
     const init = { code, data: stateInit };


### PR DESCRIPTION
## Summary
- implement USDT withdrawal timelock in `jet.fc`
- expose `TIMELOCK_DELAY_SEC` in deploy script and `.env.example`
- document new variable in README

## Testing
- `npm run build`
- `npm test` 
