### PR TITLE
Implement timelock for TON withdrawals

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,6 @@ REF_PERCENT=10 # referral payout in basis points
 # Jackpot size for TON lottery (whole TON, NOT nanoTON).
 # Default: 1000 on mainnet, 10 on testnet.
 JACKPOT_AMOUNT_TON=1000
+# Timelock delay for TON withdrawals (seconds)
+# default: 172800 on mainnet, 3600 on testnet
+TIMELOCK_DELAY_SEC_TON=172800

--- a/README.md
+++ b/README.md
@@ -51,8 +51,10 @@ The `.env` file requires the following fields:
 - `COLLECTION_OWNER` – address that will receive NFT royalties.
 - `ADMIN_ADDRESS` – address of the lottery administrator.
 - `REF_PERCENT` – referral fee in basis points.  
-- `JACKPOT_AMOUNT_TON` – jackpot size in whole TON for the TON lottery  
+- `JACKPOT_AMOUNT_TON` – jackpot size in whole TON for the TON lottery
   (defaults to 1000 TON on mainnet and 10 TON on testnet if unset).
+- `TIMELOCK_DELAY_SEC_TON` – timelock delay (in seconds) for TON withdrawals  
+  (defaults: 172 800 s on mainnet, 3 600 s on testnet).
 
 ## Compiling contracts
 

--- a/contracts/jet.fc
+++ b/contracts/jet.fc
@@ -1,5 +1,8 @@
 #include "imports/stdlib.fc";
 #include "imports/functions.fc";
+;; TON withdrawals are protected by per-contract timelock (schedule/execute).
+const int OP_SCHEDULE_TON = 2;
+const int OP_EXEC_TON     = 7;
 
 (
         cell,  ;; counters
@@ -9,7 +12,10 @@
         int,   ;; ticket_price
         int,   ;; ref_percent
         int,   ;; jackpot_amount (nanoTON)
-        int    ;; locked_jp_coins reserve
+        int,   ;; locked_jp_coins reserve
+        int,   ;; scheduled TON amount
+        int,   ;; unlock timestamp
+        int    ;; per-contract delay (sec)
 ) load_data() inline {
         var ds = get_data().begin_parse();
         return (
@@ -20,7 +26,10 @@
                 ds~load_coins(),
                 ds~load_uint(16),
                 ds~load_uint(128),
-                ds~load_uint(128)
+                ds~load_uint(128),
+                ds~load_uint(128),
+                ds~load_uint(64),
+                ds~load_uint(64)
         );
 }
 
@@ -32,7 +41,10 @@
         int price,
         int ref_percent,
         int jackpot_amount,
-        int locked_jp_coins
+        int locked_jp_coins,
+        int tl_ton_amount,
+        int tl_ton_until,
+        int tl_delay
 ) impure inline {
         set_data(
                 begin_cell()
@@ -44,9 +56,13 @@
                 .store_uint(ref_percent, 16)
                 .store_uint(jackpot_amount, 128)
                 .store_uint(locked_jp_coins, 128)
-                .end_cell()
+                .store_uint(tl_ton_amount, 128)
+                .store_uint(tl_ton_until, 64)
+                .store_uint(tl_delay, 64)
+                .end_cell(),
         );
 }
+
 
 
 
@@ -67,10 +83,11 @@
                 int price,
                 int ref_percent,
                 int jackpot_amount,
-                int locked_jp_coins
+                int locked_jp_coins,
+                int tl_ton_amount,
+                int tl_ton_until,
+                int tl_delay
         ) = load_data();
-
-        if (in_msg_body.slice_empty?() | (slice_bits(in_msg_body) == 267)) {
                 if (equal_slices(sender_address, admin_address)) {
                         return();
                 }
@@ -134,7 +151,7 @@
                                         .store_uint(x3, 16)
                                         .store_uint(x1, 16)
                                         .end_cell();
-                                store_data(new_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, jackpot_amount, locked_jp_coins);
+                                store_data(new_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, jackpot_amount, locked_jp_coins, tl_ton_amount, tl_ton_until, tl_delay);
                                 return();
                         }
                 }
@@ -153,7 +170,7 @@
 					.store_uint(x3, 16)
 					.store_uint(x1, 16)
 					.end_cell();
-                                store_data(new_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, jackpot_amount, locked_jp_coins);
+                                store_data(new_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, jackpot_amount, locked_jp_coins, tl_ton_amount, tl_ton_until, tl_delay);
 				return();
 			}
 		}
@@ -172,7 +189,7 @@
 					.store_uint(x3, 16)
 					.store_uint(x1, 16)
 					.end_cell();
-                                store_data(new_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, jackpot_amount, locked_jp_coins);
+                                store_data(new_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, jackpot_amount, locked_jp_coins, tl_ton_amount, tl_ton_until, tl_delay);
 				return();
 			}
 		}
@@ -191,7 +208,7 @@
 					.store_uint(x3, 16)
 					.store_uint(x1, 16)
 					.end_cell();
-                                store_data(new_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, jackpot_amount, locked_jp_coins);
+                                store_data(new_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, jackpot_amount, locked_jp_coins, tl_ton_amount, tl_ton_until, tl_delay);
 				return();
 			}
 		}
@@ -210,7 +227,7 @@
 					.store_uint(x3, 16)
 					.store_uint(x1, 16)
 					.end_cell();
-                                store_data(new_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, jackpot_amount, locked_jp_coins);
+                                store_data(new_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, jackpot_amount, locked_jp_coins, tl_ton_amount, tl_ton_until, tl_delay);
 				return();
 			}
 		}
@@ -229,7 +246,7 @@
 					.store_uint(x3, 16)
 					.store_uint(x1, 16)
 					.end_cell();
-                                store_data(new_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, jackpot_amount, locked_jp_coins);
+                                store_data(new_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, jackpot_amount, locked_jp_coins, tl_ton_amount, tl_ton_until, tl_delay);
 				return();
 			}
 		}
@@ -248,14 +265,14 @@
 					.store_uint(x3, 16)
 					.store_uint(x1, 16)
 					.end_cell();
-                                store_data(new_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, jackpot_amount, locked_jp_coins);
+                                store_data(new_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, jackpot_amount, locked_jp_coins, tl_ton_amount, tl_ton_until, tl_delay);
 				return();
 			}
 		}
 
 		next_ticket_index += 1;
                 send_winning(0, sender_address, "lose", collection_address, 7, 0);
-                store_data(counters_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, jackpot_amount, locked_jp_coins);
+                store_data(counters_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, jackpot_amount, locked_jp_coins, tl_ton_amount, tl_ton_until, tl_delay);
 		return();
 	}
 
@@ -263,29 +280,58 @@
 	int query_id = in_msg_body~load_uint(64);
 
 
-        if (op == 2) { ;; withdrawal
+        if (op == OP_SCHEDULE_TON) {
                 throw_unless(401, equal_slices(sender_address, admin_address));
-                int free_balance = my_balance - locked_jp_coins - 50000000;
-                throw_unless(403, free_balance > 0);
-                ;; always send the full free balance; partial withdrawal is not supported
-                int amount_to_send = free_balance;
+
+                int free = my_balance - locked_jp_coins - 50_000_000;   ;; 0.05 TON reserve
+                int req  = in_msg_body~load_uint(64);   ;; 0 → cancel
+
+                throw_unless(403, req <= free);
+
+                if (req == 0) {
+                        tl_ton_amount := 0;
+                        tl_ton_until  := 0;
+                } else {
+                        tl_ton_amount := req;
+                        tl_ton_until  := now() + tl_delay;
+                }
+
+                store_data(counters_ref, next_ticket_index, collection_address,
+                           admin_address, price, ref_percent,
+                           jackpot_amount, locked_jp_coins,
+                           tl_ton_amount, tl_ton_until, tl_delay);
+                return ();
+        }
+
+        if (op == OP_EXEC_TON) {
+                throw_unless(403, now() >= tl_ton_until);
+                throw_unless(403, tl_ton_amount > 0);
+
+                int free = my_balance - locked_jp_coins - 50_000_000;
+                throw_unless(402, tl_ton_amount <= free);
 
                 var msg = begin_cell()
                         .store_uint(0x18, 6)
                         .store_slice(admin_address)
-                        .store_coins(amount_to_send)
+                        .store_coins(tl_ton_amount)
                         .store_uint(0, 1 + 4 + 4 + 64 + 32 + 1 + 1)
                         .store_uint(0, 32)
-                        .store_slice("Contract fund reallocation")
                         .end_cell();
-
                 send_raw_message(msg, 1);
-                return();
+
+                tl_ton_amount := 0;
+                tl_ton_until  := 0;
+
+                store_data(counters_ref, next_ticket_index, collection_address,
+                           admin_address, price, ref_percent,
+                           jackpot_amount, locked_jp_coins,
+                           tl_ton_amount, tl_ton_until, tl_delay);
+                return ();
         }
 
         if (op == 3) { ;; change_admin_address
                 throw_unless(401, equal_slices(sender_address,admin_address));
-                store_data(counters_ref, next_ticket_index, collection_address, in_msg_body~load_msg_addr(), price, ref_percent, jackpot_amount, locked_jp_coins);
+                store_data(counters_ref, next_ticket_index, collection_address, in_msg_body~load_msg_addr(), price, ref_percent, jackpot_amount, locked_jp_coins, tl_ton_amount, tl_ton_until, tl_delay);
                 return();
         }
 
@@ -295,7 +341,7 @@
 }
 
 (int, int, int, int, int, int, int) get_counters() method_id {
-        (cell counters_ref, _, _, _, _, _, _, _) = load_data();
+        (cell counters_ref, _, _, _, _, _, _, _, _, _, _) = load_data();
 
 	slice counters_slice = counters_ref.begin_parse();
 		int jp = counters_slice~load_uint(16);
@@ -326,9 +372,11 @@
                 int price,
                 int ref_percent,
                 int jackpot_amount,
-                int locked_jp_coins
+                int locked_jp_coins,
+                int tl_ton_amount,
+                int tl_ton_until,
+                int tl_delay
         ) = load_data();
-
         return (
                 counters_ref,
                 next_ticket_index,
@@ -350,9 +398,12 @@
                 int price,
                 int ref_percent,
                 int jackpot_amount,
-                int locked_jp_coins
+                int locked_jp_coins,
+                int tl_ton_amount,
+                int tl_ton_until,
+                int tl_delay
         ) = load_data();
         ;; If the Jackpot transfer bounced, restore the reserve
         locked_jp_coins = jackpot_amount;  ;; restore reserve after bounced jackpot
-        store_data(counters_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, jackpot_amount, locked_jp_coins);
+        store_data(counters_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, jackpot_amount, locked_jp_coins, tl_ton_amount, tl_ton_until, tl_delay);
 }

--- a/scripts/deployJet.ts
+++ b/scripts/deployJet.ts
@@ -28,6 +28,11 @@ export async function run(provider: NetworkProvider) {
             ? 1_000n * 10n ** 9n   // 1000 TON
             : 10n    * 10n ** 9n;  // 10 TON for testnet
 
+    // timelock delay for TON withdrawals
+    const tlDelayTon = process.env.TIMELOCK_DELAY_SEC_TON
+        ? BigInt(process.env.TIMELOCK_DELAY_SEC_TON)
+        : (network === 'mainnet' ? 172800n : 3600n);   // 48 h / 1 h
+
     const jetStateInit = beginCell()
         .storeRef(
             beginCell()
@@ -47,6 +52,9 @@ export async function run(provider: NetworkProvider) {
         .storeUint(lotteryConfig.refPercent, 16)
         .storeUint(jpAmount, 128)  // jp_amount
         .storeUint(0n, 128)        // locked_jp_coins
+        .storeUint(0n, 128)        // tl_ton_amount
+        .storeUint(0n, 64)         // tl_ton_until
+        .storeUint(tlDelayTon, 64) // tl_delay
         .endCell();
 
     const jetInit = { code: jetCode, data: jetStateInit };


### PR DESCRIPTION
## Summary
- add timelock fields and opcodes in `Jet` contract
- support timelock delay in deployment script
- document new `.env` variable and README entry

## Testing
- `npm test`
- `npm run build` 
