### PR TITLE
Update withdrawal routines

### DIFF
--- a/scripts/deployJet.ts
+++ b/scripts/deployJet.ts
@@ -72,8 +72,10 @@ export async function run(provider: NetworkProvider) {
     // await setTokenWallet();
 
 
-    // await withdraw();     // Withdraw TON to admin address
-    // await withdrawUSDT(); // Withdraw USDT to any address
+    // await withdraw();               // Withdraw TON to admin address
+    // await withdrawUSDT();           // Withdraw USDT to admin address
+    // await scheduleUSDTWithdrawal(); // Schedule USDT withdrawal
+    // await executeUSDTWithdrawal();  // Execute scheduled withdrawal
 
 
     // finishRound();
@@ -109,22 +111,52 @@ export async function run(provider: NetworkProvider) {
         const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
         const ask = (q: string) => new Promise<string>(res => rl.question(q, res));
 
-        const to = await ask('Recipient address: ');
         const amountStr = await ask('Amount (USDT): ');
 
-        console.log(`Recipient: ${to}`);
         console.log(`Amount: ${amountStr} USDT`);
-        const confirm = (await ask('Confirm send? (y/N) ')).toLowerCase();
+        const confirm = (await ask('Confirm send to admin? (y/N) ')).toLowerCase();
         rl.close();
 
         if (confirm === 'y' || confirm === 'yes') {
             await jet.sendUSDT(
                 provider.sender(),
-                Address.parse(to),
+                Address.parse(lotteryConfig.adminAddress),
                 BigInt(amountStr),
                 toNano('0.1'),
             );
-            console.log('✅ USDT withdrawal sent');
+            console.log('✅ USDT withdrawal sent to admin');
+        } else {
+            console.log('Canceled');
+        }
+    }
+
+    async function scheduleUSDTWithdrawal() {
+        const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+        const ask = (q: string) => new Promise<string>(res => rl.question(q, res));
+
+        const amountStr = await ask('Amount to schedule (USDT): ');
+        console.log(`Schedule withdrawal of ${amountStr} USDT`);
+        const confirm = (await ask('Confirm schedule? (y/N) ')).toLowerCase();
+        rl.close();
+
+        if (confirm === 'y' || confirm === 'yes') {
+            await jet.sendScheduleUSDT(provider.sender(), BigInt(amountStr), toNano('0.1'));
+            console.log('✅ Withdrawal scheduled');
+        } else {
+            console.log('Canceled');
+        }
+    }
+
+    async function executeUSDTWithdrawal() {
+        const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+        const ask = (q: string) => new Promise<string>(res => rl.question(q, res));
+
+        const confirm = (await ask('Execute scheduled withdrawal? (y/N) ')).toLowerCase();
+        rl.close();
+
+        if (confirm === 'y' || confirm === 'yes') {
+            await jet.sendExecuteUSDT(provider.sender(), toNano('0.1'));
+            console.log('✅ Scheduled withdrawal executed');
         } else {
             console.log('Canceled');
         }
@@ -136,14 +168,7 @@ export async function run(provider: NetworkProvider) {
         await jet.sendWithdraw(provider.sender(), toNano('0.01'));
     }
 
-    // Stops the lottery contract and mints an NFT for the winner
-    async function finishRound(winner_address: string) {
-        await jet.sendFinishRound(
-            provider.sender(),
-            Address.parse(winner_address),
-            toNano(0.05),
-        );
-    }
+    // finishRound() disabled
 
     await provider.waitForDeploy(jet.address);
 }

--- a/wrappers/Jet.ts
+++ b/wrappers/Jet.ts
@@ -1,5 +1,5 @@
 import { Address, beginCell, Cell, Contract, contractAddress, ContractProvider, Sender, SendMode } from '@ton/core';
-import { OP_SEND_USDT } from './opcodes';
+import { OP_SEND_USDT, OP_SCHEDULE_USDT, OP_EXEC_USDT } from './opcodes';
 
 export type JetConfig = {
     collectionAddress: Address;
@@ -95,6 +95,31 @@ export class Jet implements Contract {
 
     async sendWithdraw(provider: ContractProvider, via: Sender, value: bigint) {
         const body = beginCell().storeUint(2, 32).storeUint(0, 64).endCell();
+        await provider.internal(via, {
+            value,
+            sendMode: SendMode.PAY_GAS_SEPARATELY,
+            body,
+        });
+    }
+
+    async sendScheduleUSDT(provider: ContractProvider, via: Sender, amount: bigint, value: bigint) {
+        const body = beginCell()
+            .storeUint(OP_SCHEDULE_USDT, 32)
+            .storeUint(0, 64)
+            .storeUint(amount, 128)
+            .endCell();
+        await provider.internal(via, {
+            value,
+            sendMode: SendMode.PAY_GAS_SEPARATELY,
+            body,
+        });
+    }
+
+    async sendExecuteUSDT(provider: ContractProvider, via: Sender, value: bigint) {
+        const body = beginCell()
+            .storeUint(OP_EXEC_USDT, 32)
+            .storeUint(0, 64)
+            .endCell();
         await provider.internal(via, {
             value,
             sendMode: SendMode.PAY_GAS_SEPARATELY,

--- a/wrappers/opcodes.ts
+++ b/wrappers/opcodes.ts
@@ -1,3 +1,5 @@
 export const OP_JETTON_TRANSFER_NOTIFICATION = 0x7362d09c;
 export const OP_SEND_USDT = 0x55534454;
 export const OP_DEPLOY_WALLET = 0x0c0d5934;
+export const OP_SCHEDULE_USDT = 6;
+export const OP_EXEC_USDT = 7;


### PR DESCRIPTION
## Summary
- simplify USDT withdrawal in `deployJet.ts`
- remove deprecated `finishRound` function from the admin script
- add functions to schedule and execute USDT withdrawals
- expose schedule and execute opcodes via wrapper constants
- implement wrapper helpers for the new opcodes

## Testing
- `npm test`