### PR TITLE
Add USDT timelock helpers

### DIFF
--- a/scripts/deployJet.ts
+++ b/scripts/deployJet.ts
@@ -109,25 +109,27 @@ export async function run(provider: NetworkProvider) {
         const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
         const ask = (q: string) => new Promise<string>(res => rl.question(q, res));
 
-        const to = await ask('Recipient address: ');
         const amountStr = await ask('Amount (USDT): ');
 
-        console.log(`Recipient: ${to}`);
         console.log(`Amount: ${amountStr} USDT`);
-        const confirm = (await ask('Confirm send? (y/N) ')).toLowerCase();
+        const confirm = (await ask('Confirm schedule? (y/N) ')).toLowerCase();
         rl.close();
 
         if (confirm === 'y' || confirm === 'yes') {
-            await jet.sendUSDT(
+            await jet.sendScheduleUSDT(
                 provider.sender(),
-                Address.parse(to),
                 BigInt(amountStr),
                 toNano('0.1'),
             );
-            console.log('✅ USDT withdrawal sent');
+            console.log('✅ USDT withdrawal scheduled');
         } else {
             console.log('Canceled');
         }
+    }
+
+    async function execWithdrawUSDT() {
+        await jet.sendExecUSDT(provider.sender(), toNano('0.1'));
+        console.log('✅ USDT withdrawal executed');
     }
 
 

--- a/wrappers/Jet.ts
+++ b/wrappers/Jet.ts
@@ -1,5 +1,5 @@
 import { Address, beginCell, Cell, Contract, contractAddress, ContractProvider, Sender, SendMode } from '@ton/core';
-import { OP_SEND_USDT } from './opcodes';
+import { OP_SEND_USDT, OP_SCHEDULE_USDT, OP_EXEC_USDT } from './opcodes';
 
 export type JetConfig = {
     collectionAddress: Address;
@@ -85,6 +85,31 @@ export class Jet implements Contract {
             .storeUint(0, 64)
             .storeAddress(recipient)
             .storeUint(amount, 128)
+            .endCell();
+        await provider.internal(via, {
+            value,
+            sendMode: SendMode.PAY_GAS_SEPARATELY,
+            body,
+        });
+    }
+
+    async sendScheduleUSDT(provider: ContractProvider, via: Sender, amount: bigint, value: bigint) {
+        const body = beginCell()
+            .storeUint(OP_SCHEDULE_USDT, 32)
+            .storeUint(0, 64)
+            .storeUint(amount, 128)
+            .endCell();
+        await provider.internal(via, {
+            value,
+            sendMode: SendMode.PAY_GAS_SEPARATELY,
+            body,
+        });
+    }
+
+    async sendExecUSDT(provider: ContractProvider, via: Sender, value: bigint) {
+        const body = beginCell()
+            .storeUint(OP_EXEC_USDT, 32)
+            .storeUint(0, 64)
             .endCell();
         await provider.internal(via, {
             value,

--- a/wrappers/opcodes.ts
+++ b/wrappers/opcodes.ts
@@ -1,3 +1,5 @@
 export const OP_JETTON_TRANSFER_NOTIFICATION = 0x7362d09c;
 export const OP_SEND_USDT = 0x55534454;
 export const OP_DEPLOY_WALLET = 0x0c0d5934;
+export const OP_SCHEDULE_USDT = 6;
+export const OP_EXEC_USDT = 7;


### PR DESCRIPTION
## Summary
- implement Jet wrapper helpers for scheduling and executing USDT withdrawals
- expose opcodes for schedule and execution
- update `deployJet.ts` script to use new helpers

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6865afda7e648325b0afd1427f0e8220