### PR TITLE
Remove deprecated finishRound wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ and new tickets remain fully valid for those rewards.
 3. Adjust `lotteryConfig` in `scripts/deployJet.ts` and select `deployJet` to deploy the lottery contract.
 4. From the same script run `setLotteryAddress()` so the lottery contract can mint NFTs.
 
-The `deployJet.ts` script also exposes `withdraw()`, `withdrawUSDT()` and `finishRound(winner)` for administrative actions.
+The `deployJet.ts` script also exposes `withdraw()` and `withdrawUSDT()` for administrative actions.
 
 ## NFT Collection
 The lottery issues unique NFTs for every prize tier. Metadata for each token can be found in the `lottery_metadata` directory and is pinned to IPFS. The collection contract stores the lottery address alongside the owner address, next item index and royalty details. The collection is deployed once and the lottery contract mints the appropriate token when a player wins.
@@ -40,7 +40,7 @@ Send a jetton `transfer` to the lottery wallet with the amount equal to `TICKET_
 
 ## Lottery Mechanics
 1. After receiving a payment, the contract generates a random number `x` from 0 to 11 999.
-2. If `x == 0` the contract informs the administrator about a potential jackpot. The admin should call `finishRound(address)`:
+2. If `x == 0` the contract informs the administrator about a potential jackpot.
    - the player receives `JACKPOT_PRIZE` (10 000 jettons) and NFT `0`;
    - the Jackpot counter increases; remaining prize tiers continue as usual.
 3. Otherwise `x` is checked against the ranges below. A prize is issued while the associated counter is below its limit. The table assumes a round of 12 000 tickets.

--- a/scripts/deployJet.ts
+++ b/scripts/deployJet.ts
@@ -78,7 +78,6 @@ export async function run(provider: NetworkProvider) {
     // await executeUSDTWithdrawal();  // Execute scheduled withdrawal
 
 
-    // finishRound();
 
 
 
@@ -168,7 +167,6 @@ export async function run(provider: NetworkProvider) {
         await jet.sendWithdraw(provider.sender(), toNano('0.01'));
     }
 
-    // finishRound() disabled
 
     await provider.waitForDeploy(jet.address);
 }

--- a/wrappers/Jet.spec.ts
+++ b/wrappers/Jet.spec.ts
@@ -85,18 +85,11 @@ describe('Jet', () => {
         expect(Number(counters.low)).toBeLessThanOrEqual(47);
         expect(Number(counters.mini)).toBeLessThanOrEqual(152);
 
-        const before = await jet.getCounters();
-
-        const finish = await jet.sendFinishRound(deployer.getSender(), player.address, toNano('0.27'));
-        expect(finish.transactions).toHaveTransaction({ exitCode: 0 });
-
-        const after = await jet.getCounters();
-        expect(Number(after.jackpot)).toBeGreaterThanOrEqual(Number(before.jackpot));
+        const countersBefore = await jet.getCounters();
 
         await sendTicket(player);
 
-        const final = await jet.getCounters();
-        expect(Number(final.jackpot)).toBeGreaterThanOrEqual(Number(after.jackpot));
-        expect(Number(final.major)).toBe(Number(after.major));
+        const after = await jet.getCounters();
+        expect(Number(after.jackpot)).toBeGreaterThanOrEqual(Number(countersBefore.jackpot));
     });
 });

--- a/wrappers/Jet.ts
+++ b/wrappers/Jet.ts
@@ -127,14 +127,6 @@ export class Jet implements Contract {
         });
     }
 
-    async sendFinishRound(provider: ContractProvider, via: Sender, winner: Address, value: bigint) {
-        const body = beginCell().storeUint(4, 32).storeUint(0, 64).storeAddress(winner).endCell();
-        await provider.internal(via, {
-            value,
-            sendMode: SendMode.PAY_GAS_SEPARATELY,
-            body,
-        });
-    }
 
     async getCounters(provider: ContractProvider) {
         const res = await provider.get('get_counters', []);


### PR DESCRIPTION
## Summary
- delete `sendFinishRound` from `Jet` wrapper
- drop calls to `finishRound` from the deployment script
- update documentation to not mention `finishRound`
- adjust unit tests