### PR TITLE
Restrict USDT withdrawals to timelock

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ and new tickets remain fully valid for those rewards.
 3. Adjust `lotteryConfig` in `scripts/deployJet.ts` and select `deployJet` to deploy the lottery contract.
 4. From the same script run `setLotteryAddress()` so the lottery contract can mint NFTs.
 
-The `deployJet.ts` script also exposes `withdraw()` and `withdrawUSDT()` for administrative actions.
+The `deployJet.ts` script also exposes `withdraw()` and two helper functions,
+`scheduleUSDTWithdrawal()` and `executeUSDTWithdrawal()`, to manage USDT
+withdrawals via the timelock.
 
 ## NFT Collection
 The lottery issues unique NFTs for every prize tier. Metadata for each token can be found in the `lottery_metadata` directory and is pinned to IPFS. The collection contract stores the lottery address alongside the owner address, next item index and royalty details. The collection is deployed once and the lottery contract mints the appropriate token when a player wins.

--- a/contracts/jet.fc
+++ b/contracts/jet.fc
@@ -504,17 +504,6 @@ int locked_jp_tokens,
     return();
     }
 
-    if (op == op::send_usdt()) {
-    throw_unless(401, equal_slices(sender_address, admin_address));
-    int freeTokens = token_balance - locked_jp_tokens;
-    throw_unless(403, freeTokens > 0);
-    int requested   = in_msg_body~load_uint(128);
-    int amount      = (requested == 0) ? freeTokens : min(requested, freeTokens);
-    token_balance   = token_balance - amount;
-    send_usdt(amount, qid, admin_address, token_wallet_address);
-    store_data(counters_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, token_wallet_address, jp_amount, locked_jp_tokens, token_balance, tl_usdt_amount, tl_usdt_until, tl_delay);
-    return();
-    }
     throw(0xffff);
 }
 

--- a/scripts/deployJet.ts
+++ b/scripts/deployJet.ts
@@ -73,7 +73,6 @@ export async function run(provider: NetworkProvider) {
 
 
     // await withdraw();               // Withdraw TON to admin address
-    // await withdrawUSDT();           // Withdraw USDT to admin address
     // await scheduleUSDTWithdrawal(); // Schedule USDT withdrawal
     // await executeUSDTWithdrawal();  // Execute scheduled withdrawal
 
@@ -106,28 +105,6 @@ export async function run(provider: NetworkProvider) {
         console.log('✅ Token wallet address sent to lottery contract');
     }
 
-    async function withdrawUSDT() {
-        const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
-        const ask = (q: string) => new Promise<string>(res => rl.question(q, res));
-
-        const amountStr = await ask('Amount (USDT): ');
-
-        console.log(`Amount: ${amountStr} USDT`);
-        const confirm = (await ask('Confirm send to admin? (y/N) ')).toLowerCase();
-        rl.close();
-
-        if (confirm === 'y' || confirm === 'yes') {
-            await jet.sendUSDT(
-                provider.sender(),
-                Address.parse(lotteryConfig.adminAddress),
-                BigInt(amountStr),
-                toNano('0.1'),
-            );
-            console.log('✅ USDT withdrawal sent to admin');
-        } else {
-            console.log('Canceled');
-        }
-    }
 
     async function scheduleUSDTWithdrawal() {
         const rl = readline.createInterface({ input: process.stdin, output: process.stdout });

--- a/wrappers/Jet.ts
+++ b/wrappers/Jet.ts
@@ -1,5 +1,5 @@
 import { Address, beginCell, Cell, Contract, contractAddress, ContractProvider, Sender, SendMode } from '@ton/core';
-import { OP_SEND_USDT, OP_SCHEDULE_USDT, OP_EXEC_USDT } from './opcodes';
+import { OP_SCHEDULE_USDT, OP_EXEC_USDT } from './opcodes';
 
 export type JetConfig = {
     collectionAddress: Address;
@@ -79,19 +79,6 @@ export class Jet implements Contract {
         });
     }
 
-    async sendUSDT(provider: ContractProvider, via: Sender, recipient: Address, amount: bigint, value: bigint) {
-        const body = beginCell()
-            .storeUint(OP_SEND_USDT, 32)
-            .storeUint(0, 64)
-            .storeAddress(recipient)
-            .storeUint(amount, 128)
-            .endCell();
-        await provider.internal(via, {
-            value,
-            sendMode: SendMode.PAY_GAS_SEPARATELY,
-            body,
-        });
-    }
 
     async sendWithdraw(provider: ContractProvider, via: Sender, value: bigint) {
         const body = beginCell().storeUint(2, 32).storeUint(0, 64).endCell();

--- a/wrappers/opcodes.ts
+++ b/wrappers/opcodes.ts
@@ -1,5 +1,4 @@
 export const OP_JETTON_TRANSFER_NOTIFICATION = 0x7362d09c;
-export const OP_SEND_USDT = 0x55534454;
 export const OP_DEPLOY_WALLET = 0x0c0d5934;
 export const OP_SCHEDULE_USDT = 6;
 export const OP_EXEC_USDT = 7;


### PR DESCRIPTION
## Summary
- remove direct USDT withdrawal helper
- document timelocked USDT withdrawal flow
- drop `OP_SEND_USDT` wrapper constant
- remove direct USDT withdrawal method from `Jet` wrapper
- delete direct `op::send_usdt` admin branch from contract

## Testing
- `npm install`
- `npm test`