### PR TITLE
feat(ton): add 2-step timelock for TON withdrawals

### DIFF
--- a/contracts/jet.fc
+++ b/contracts/jet.fc
@@ -2,7 +2,7 @@
 #include "imports/functions.fc";
 
 ;; Jackpot is paid automatically; no admin trigger exists.
-;; USDT withdrawals use timelock (op 6/7), TON withdrawals are instant.
+;; USDT and TON withdrawals use timelock (op 6/7 & 11/12).
 
 int JACKPOT_PRIZE() asm "10000 PUSHINT"; ;; 10,000 tokens
 int MAJOR_PRIZE() asm "1800 PUSHINT";    ;; 1,800 tokens
@@ -17,6 +17,8 @@ const int OP_EXEC_USDT     = 7;
 const int OP_SCHEDULE_ADMIN = 8;
 const int OP_EXEC_ADMIN     = 9;
 const int OP_CANCEL_ADMIN   = 10;
+const int OP_SCHEDULE_TON = 11;
+const int OP_EXEC_TON     = 12;
 
 (
     cell, ;; counters
@@ -31,7 +33,9 @@ const int OP_CANCEL_ADMIN   = 10;
     int,   ;; token_balance
     int,   ;; tl_usdt_amount
     int,   ;; tl_usdt_until
-    int    ;; tl_delay
+    int,   ;; tl_delay
+    int,   ;; tl_ton_amount
+    int    ;; tl_ton_until
 ) load_data() inline {
     var ds = get_data().begin_parse();
     return (
@@ -47,6 +51,8 @@ const int OP_CANCEL_ADMIN   = 10;
         ds~load_uint(128),
         ds~load_uint(128),
         ds~load_uint(64),
+        ds~load_uint(64),
+        ds~load_uint(128),
         ds~load_uint(64)
     );
 }
@@ -64,7 +70,9 @@ int locked_jp_tokens,
     int token_balance,
     int tl_usdt_amount,
     int tl_usdt_until,
-    int tl_delay
+    int tl_delay,
+    int tl_ton_amount,
+    int tl_ton_until
 ) impure inline {
     set_data(
         begin_cell()
@@ -81,6 +89,8 @@ int locked_jp_tokens,
             .store_uint(tl_usdt_amount, 128)
             .store_uint(tl_usdt_until, 64)
             .store_uint(tl_delay, 64)
+            .store_uint(tl_ton_amount, 128)
+            .store_uint(tl_ton_until, 64)
             .end_cell()
     );
 }
@@ -112,7 +122,9 @@ int locked_jp_tokens,
         int token_balance,
         int tl_usdt_amount,
         int tl_usdt_until,
-        int tl_delay
+        int tl_delay,
+        int tl_ton_amount,
+        int tl_ton_until
     ) = load_data();
 
     int op = in_msg_body.preload_uint(32);
@@ -265,7 +277,7 @@ int locked_jp_tokens,
                 store_data(new_ref, next_ticket_index, collection_address,
                            admin_address, price, ref_percent,
                            token_wallet_address, jp_amount, locked_jp_tokens,
-                           token_balance, tl_usdt_amount, tl_usdt_until, tl_delay);
+                           token_balance, tl_usdt_amount, tl_usdt_until, tl_delay, tl_ton_amount, tl_ton_until);
                 return ();
             }
         }
@@ -286,7 +298,7 @@ int locked_jp_tokens,
                     .store_uint(low, 16)
                     .store_uint(mini, 16)
                     .end_cell();
-                store_data(new_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, token_wallet_address, jp_amount, locked_jp_tokens, token_balance, tl_usdt_amount, tl_usdt_until, tl_delay);
+                store_data(new_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, token_wallet_address, jp_amount, locked_jp_tokens, token_balance, tl_usdt_amount, tl_usdt_until, tl_delay, tl_ton_amount, tl_ton_until);
                 return();
             }
         }
@@ -309,7 +321,7 @@ int locked_jp_tokens,
                     .store_uint(low, 16)
                     .store_uint(mini, 16)
                     .end_cell();
-                store_data(new_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, token_wallet_address, jp_amount, locked_jp_tokens, token_balance, tl_usdt_amount, tl_usdt_until, tl_delay);
+                store_data(new_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, token_wallet_address, jp_amount, locked_jp_tokens, token_balance, tl_usdt_amount, tl_usdt_until, tl_delay, tl_ton_amount, tl_ton_until);
                 return();
             }
         }
@@ -332,7 +344,7 @@ int locked_jp_tokens,
                     .store_uint(low, 16)
                     .store_uint(mini, 16)
                     .end_cell();
-                store_data(new_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, token_wallet_address, jp_amount, locked_jp_tokens, token_balance, tl_usdt_amount, tl_usdt_until, tl_delay);
+                store_data(new_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, token_wallet_address, jp_amount, locked_jp_tokens, token_balance, tl_usdt_amount, tl_usdt_until, tl_delay, tl_ton_amount, tl_ton_until);
                 return();
             }
         }
@@ -355,7 +367,7 @@ int locked_jp_tokens,
                     .store_uint(low, 16)
                     .store_uint(mini, 16)
                     .end_cell();
-                store_data(new_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, token_wallet_address, jp_amount, locked_jp_tokens, token_balance, tl_usdt_amount, tl_usdt_until, tl_delay);
+                store_data(new_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, token_wallet_address, jp_amount, locked_jp_tokens, token_balance, tl_usdt_amount, tl_usdt_until, tl_delay, tl_ton_amount, tl_ton_until);
                 return();
             }
         }
@@ -378,7 +390,7 @@ int locked_jp_tokens,
                     .store_uint(low, 16)
                     .store_uint(mini, 16)
                     .end_cell();
-                store_data(new_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, token_wallet_address, jp_amount, locked_jp_tokens, token_balance, tl_usdt_amount, tl_usdt_until, tl_delay);
+                store_data(new_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, token_wallet_address, jp_amount, locked_jp_tokens, token_balance, tl_usdt_amount, tl_usdt_until, tl_delay, tl_ton_amount, tl_ton_until);
                 return();
             }
         }
@@ -401,7 +413,7 @@ int locked_jp_tokens,
                     .store_uint(low, 16)
                     .store_uint(mini, 16)
                     .end_cell();
-                store_data(new_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, token_wallet_address, jp_amount, locked_jp_tokens, token_balance, tl_usdt_amount, tl_usdt_until, tl_delay);
+                store_data(new_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, token_wallet_address, jp_amount, locked_jp_tokens, token_balance, tl_usdt_amount, tl_usdt_until, tl_delay, tl_ton_amount, tl_ton_until);
                 return();
             }
         }
@@ -410,7 +422,7 @@ int locked_jp_tokens,
 
         send_winning(0, qid, player_address, 7, collection_address, 7, token_wallet_address);
 
-        store_data(counters_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, token_wallet_address, jp_amount, locked_jp_tokens, token_balance, tl_usdt_amount, tl_usdt_until, tl_delay);
+        store_data(counters_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, token_wallet_address, jp_amount, locked_jp_tokens, token_balance, tl_usdt_amount, tl_usdt_until, tl_delay, tl_ton_amount, tl_ton_until);
 
         return();
         }
@@ -433,7 +445,7 @@ int locked_jp_tokens,
             store_data(counters_ref, next_ticket_index, collection_address,
                        admin_address, price, ref_percent,
                        token_wallet_address, jp_amount, locked_jp_tokens,
-                       token_balance, tl_usdt_amount, tl_usdt_until, tl_delay);
+                       token_balance, tl_usdt_amount, tl_usdt_until, tl_delay, tl_ton_amount, tl_ton_until);
             return();
         }
     }
@@ -461,7 +473,7 @@ int locked_jp_tokens,
         store_data(counters_ref, next_ticket_index, collection_address,
                    admin_address, price, ref_percent,
                    token_wallet_address, jp_amount, locked_jp_tokens,
-                   token_balance, tl_usdt_amount, tl_usdt_until, tl_delay);
+                   token_balance, tl_usdt_amount, tl_usdt_until, tl_delay, tl_ton_amount, tl_ton_until);
         return ();
     }
 
@@ -480,25 +492,50 @@ int locked_jp_tokens,
         store_data(counters_ref, next_ticket_index, collection_address,
                    admin_address, price, ref_percent,
                    token_wallet_address, jp_amount, locked_jp_tokens,
-                   token_balance, tl_usdt_amount, tl_usdt_until, tl_delay);
+                   token_balance, tl_usdt_amount, tl_usdt_until, tl_delay, tl_ton_amount, tl_ton_until);
         return ();
     }
 
-    if (op == 2) { ;; withdrawal
+    if (op == OP_SCHEDULE_TON) {
         throw_unless(401, equal_slices(sender_address, admin_address));
-        throw_unless(403, my_balance > 50000000); ;; 0.05 TON
+        int freeTon = my_balance - 50000000;
+        int req     = in_msg_body~load_uint(64);
+        throw_unless(403, req <= freeTon);
+
+        tl_ton_amount = req;
+        tl_ton_until  = (req == 0) ? 0 : now() + tl_delay;
+        store_data(counters_ref, next_ticket_index, collection_address,
+                   admin_address, price, ref_percent,
+                   token_wallet_address, jp_amount, locked_jp_tokens,
+                   token_balance, tl_usdt_amount, tl_usdt_until, tl_delay, tl_ton_amount, tl_ton_until);
+        return ();
+    }
+
+    if (op == OP_EXEC_TON) {
+        throw_unless(401, equal_slices(sender_address, admin_address));
+        throw_unless(403, tl_ton_amount > 0);
+        throw_unless(403, now() >= tl_ton_until);
+
+        int freeTon = my_balance - 50000000;
+        throw_unless(402, tl_ton_amount <= freeTon);
 
         var msg = begin_cell()
             .store_uint(flag::bounce(), 6)
             .store_slice(admin_address)
-            .store_coins(my_balance - 50000000)
+            .store_coins(tl_ton_amount)
             .store_uint(0, 1 + 4 + 4 + 64 + 32 + 1 + 1)
             .store_uint(0, 32)
-            .store_slice("Contract fund reallocation")
+            .store_slice("timelocked TON withdraw")
             .end_cell();
-
         send_raw_message(msg, 1);
-        return();
+
+        tl_ton_amount = 0;
+        tl_ton_until  = 0;
+        store_data(counters_ref, next_ticket_index, collection_address,
+                   admin_address, price, ref_percent,
+                   token_wallet_address, jp_amount, locked_jp_tokens,
+                   token_balance, tl_usdt_amount, tl_usdt_until, tl_delay, tl_ton_amount, tl_ton_until);
+        return ();
     }
 
 
@@ -530,7 +567,7 @@ int locked_jp_tokens,
             .store_uint(now() + tl_delay, 64)
             .end_cell();
 
-        store_data(new_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, token_wallet_address, jp_amount, locked_jp_tokens, token_balance, tl_usdt_amount, tl_usdt_until, tl_delay);
+        store_data(new_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, token_wallet_address, jp_amount, locked_jp_tokens, token_balance, tl_usdt_amount, tl_usdt_until, tl_delay, tl_ton_amount, tl_ton_until);
         return();
     }
 
@@ -561,7 +598,7 @@ int locked_jp_tokens,
             .store_uint(0, 64)
             .end_cell();
 
-        store_data(new_ref, next_ticket_index, collection_address, pending_admin, price, ref_percent, token_wallet_address, jp_amount, locked_jp_tokens, token_balance, tl_usdt_amount, tl_usdt_until, tl_delay);
+        store_data(new_ref, next_ticket_index, collection_address, pending_admin, price, ref_percent, token_wallet_address, jp_amount, locked_jp_tokens, token_balance, tl_usdt_amount, tl_usdt_until, tl_delay, tl_ton_amount, tl_ton_until);
         return();
     }
 
@@ -591,14 +628,14 @@ int locked_jp_tokens,
             .store_uint(0, 64)
             .end_cell();
 
-        store_data(new_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, token_wallet_address, jp_amount, locked_jp_tokens, token_balance, tl_usdt_amount, tl_usdt_until, tl_delay);
+        store_data(new_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, token_wallet_address, jp_amount, locked_jp_tokens, token_balance, tl_usdt_amount, tl_usdt_until, tl_delay, tl_ton_amount, tl_ton_until);
         return();
     }
 
 
     if (op == 5) { ;; set token_wallet_address
     throw_unless(401, equal_slices(sender_address, admin_address));
-    store_data(counters_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, in_msg_body~load_msg_addr(), jp_amount, locked_jp_tokens, token_balance, tl_usdt_amount, tl_usdt_until, tl_delay);
+    store_data(counters_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, in_msg_body~load_msg_addr(), jp_amount, locked_jp_tokens, token_balance, tl_usdt_amount, tl_usdt_until, tl_delay, tl_ton_amount, tl_ton_until);
     return();
     }
 
@@ -606,7 +643,7 @@ int locked_jp_tokens,
 }
 
 (int, int, int, int, int, int, int) get_counters() method_id {
-    (cell counters_ref, _, _, _, _, _, _, _, _, _, _, _, _) = load_data();
+(cell counters_ref, _, _, _, _, _, _, _, _, _, _, _, _, _, _) = load_data();
 
     slice counters_slice = counters_ref.begin_parse();
     int jp = counters_slice~load_uint(16);
@@ -629,7 +666,7 @@ int locked_jp_tokens,
 
 
 
-(cell, int, slice, slice, int, int, slice, int, int, int, int, int, int) get_full_data() method_id {
+(cell, int, slice, slice, int, int, slice, int, int, int, int, int, int, int, int) get_full_data() method_id {
     var (
         cell counters_ref,
         int next_ticket_index,
@@ -643,7 +680,9 @@ int locked_jp_tokens,
         int token_balance,
         int tl_usdt_amount,
         int tl_usdt_until,
-        int tl_delay
+        int tl_delay,
+        int tl_ton_amount,
+        int tl_ton_until
     ) = load_data();
 
     return (
@@ -659,7 +698,9 @@ int locked_jp_tokens,
         token_balance,
         tl_usdt_amount,
         tl_usdt_until,
-        tl_delay
+        tl_delay,
+        tl_ton_amount,
+        tl_ton_until
     );
 }
 
@@ -677,10 +718,12 @@ int locked_jp_tokens,
         int token_balance,
         int tl_usdt_amount,
         int tl_usdt_until,
-        int tl_delay
+        int tl_delay,
+        int tl_ton_amount,
+        int tl_ton_until
     ) = load_data();
 
     locked_jp_tokens = jp_amount;
 
-    store_data(counters_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, token_wallet_address, jp_amount, locked_jp_tokens, token_balance, tl_usdt_amount, tl_usdt_until, tl_delay);
+    store_data(counters_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, token_wallet_address, jp_amount, locked_jp_tokens, token_balance, tl_usdt_amount, tl_usdt_until, tl_delay, tl_ton_amount, tl_ton_until);
 }

--- a/scripts/deployJet.ts
+++ b/scripts/deployJet.ts
@@ -62,6 +62,8 @@ export async function run(provider: NetworkProvider) {
         .storeUint(0n, 128)       // tl_usdt_amount
         .storeUint(0n, 64)        // tl_usdt_until
         .storeUint(tlDelay, 64)   // tl_delay
+        .storeUint(0n, 128)       // tl_ton_amount
+        .storeUint(0n, 64)        // tl_ton_until
         .endCell();
 
     const init = { code, data: stateInit };
@@ -72,7 +74,8 @@ export async function run(provider: NetworkProvider) {
     // await setTokenWallet();
 
 
-    // await withdraw();               // Withdraw TON to admin address
+    // await scheduleTONWithdrawal();   // Schedule TON withdrawal
+    // await executeTONWithdrawal();    // Execute scheduled TON withdrawal
     // await scheduleUSDTWithdrawal(); // Schedule USDT withdrawal
     // await executeUSDTWithdrawal();  // Execute scheduled withdrawal
     // await scheduleAdminChange();    // Schedule admin change
@@ -125,6 +128,23 @@ export async function run(provider: NetworkProvider) {
         }
     }
 
+    async function scheduleTONWithdrawal() {
+        const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+        const ask = (q: string) => new Promise<string>(res => rl.question(q, res));
+
+        const amountStr = await ask('Amount to schedule (TON): ');
+        console.log(`Schedule withdrawal of ${amountStr} nanoTON`);
+        const confirm = (await ask('Confirm schedule? (y/N) ')).toLowerCase();
+        rl.close();
+
+        if (confirm === 'y' || confirm === 'yes') {
+            await jet.sendScheduleTON(provider.sender(), BigInt(amountStr), toNano('0.1'));
+            console.log('✅ Withdrawal scheduled');
+        } else {
+            console.log('Canceled');
+        }
+    }
+
     async function executeUSDTWithdrawal() {
         const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
         const ask = (q: string) => new Promise<string>(res => rl.question(q, res));
@@ -135,6 +155,21 @@ export async function run(provider: NetworkProvider) {
         if (confirm === 'y' || confirm === 'yes') {
             await jet.sendExecuteUSDT(provider.sender(), toNano('0.1'));
             console.log('✅ Scheduled withdrawal executed');
+        } else {
+            console.log('Canceled');
+        }
+    }
+
+    async function executeTONWithdrawal() {
+        const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+        const ask = (q: string) => new Promise<string>(res => rl.question(q, res));
+
+        const confirm = (await ask('Execute scheduled TON withdrawal? (y/N) ')).toLowerCase();
+        rl.close();
+
+        if (confirm === 'y' || confirm === 'yes') {
+            await jet.sendExecuteTON(provider.sender(), toNano('0.1'));
+            console.log('✅ Scheduled TON withdrawal executed');
         } else {
             console.log('Canceled');
         }
@@ -170,12 +205,6 @@ export async function run(provider: NetworkProvider) {
         } else {
             console.log('Canceled');
         }
-    }
-
-
-    // Withdraws funds from the lottery contract. The balance must exceed 0.05 TON
-    async function withdraw() {
-        await jet.sendWithdraw(provider.sender(), toNano('0.01'));
     }
 
 

--- a/wrappers/Jet.ts
+++ b/wrappers/Jet.ts
@@ -1,5 +1,5 @@
 import { Address, beginCell, Cell, Contract, contractAddress, ContractProvider, Sender, SendMode } from '@ton/core';
-import { OP_SCHEDULE_USDT, OP_EXEC_USDT, OP_SCHEDULE_ADMIN, OP_EXEC_ADMIN, OP_CANCEL_ADMIN } from "./opcodes";
+import { OP_SCHEDULE_USDT, OP_EXEC_USDT, OP_SCHEDULE_ADMIN, OP_EXEC_ADMIN, OP_CANCEL_ADMIN, OP_SCHEDULE_TON, OP_EXEC_TON } from "./opcodes";
 
 export type JetConfig = {
     collectionAddress: Address;
@@ -13,6 +13,8 @@ export type JetConfig = {
     tlUsdtAmount?: bigint;
     tlUsdtUntil?: bigint;
     tlDelay?: bigint;
+    tlTonAmount?: bigint;
+    tlTonUntil?: bigint;
     newAdminAddress?: Address;
     tlAdminUntil?: bigint;
 };
@@ -46,6 +48,8 @@ export function jetConfigToCell(config: JetConfig): Cell {
             .storeUint(config.tlUsdtAmount ?? 0n, 128)
             .storeUint(config.tlUsdtUntil ?? 0n, 64)
             .storeUint(config.tlDelay ?? 0n, 64)
+            .storeUint(config.tlTonAmount ?? 0n, 128)
+            .storeUint(config.tlTonUntil ?? 0n, 64)
             .endCell()
     );
 }
@@ -84,14 +88,6 @@ export class Jet implements Contract {
     }
 
 
-    async sendWithdraw(provider: ContractProvider, via: Sender, value: bigint) {
-        const body = beginCell().storeUint(2, 32).storeUint(0, 64).endCell();
-        await provider.internal(via, {
-            value,
-            sendMode: SendMode.PAY_GAS_SEPARATELY,
-            body,
-        });
-    }
 
     async sendScheduleUSDT(provider: ContractProvider, via: Sender, amount: bigint, value: bigint) {
         const body = beginCell()
@@ -109,6 +105,31 @@ export class Jet implements Contract {
     async sendExecuteUSDT(provider: ContractProvider, via: Sender, value: bigint) {
         const body = beginCell()
             .storeUint(OP_EXEC_USDT, 32)
+            .storeUint(0, 64)
+            .endCell();
+        await provider.internal(via, {
+            value,
+            sendMode: SendMode.PAY_GAS_SEPARATELY,
+            body,
+        });
+    }
+
+    async sendScheduleTON(provider: ContractProvider, via: Sender, amount: bigint, value: bigint) {
+        const body = beginCell()
+            .storeUint(OP_SCHEDULE_TON, 32)
+            .storeUint(0, 64)
+            .storeUint(amount, 64)
+            .endCell();
+        await provider.internal(via, {
+            value,
+            sendMode: SendMode.PAY_GAS_SEPARATELY,
+            body,
+        });
+    }
+
+    async sendExecuteTON(provider: ContractProvider, via: Sender, value: bigint) {
+        const body = beginCell()
+            .storeUint(OP_EXEC_TON, 32)
             .storeUint(0, 64)
             .endCell();
         await provider.internal(via, {
@@ -185,6 +206,8 @@ export class Jet implements Contract {
             tlUsdtAmount: res.stack.readBigNumber(),
             tlUsdtUntil: res.stack.readBigNumber(),
             tlDelay: res.stack.readBigNumber(),
+            tlTonAmount: res.stack.readBigNumber(),
+            tlTonUntil: res.stack.readBigNumber(),
         };
     }
 }

--- a/wrappers/opcodes.ts
+++ b/wrappers/opcodes.ts
@@ -5,3 +5,5 @@ export const OP_EXEC_USDT = 7;
 export const OP_SCHEDULE_ADMIN = 8;
 export const OP_EXEC_ADMIN = 9;
 export const OP_CANCEL_ADMIN = 10;
+export const OP_SCHEDULE_TON = 11;
+export const OP_EXEC_TON = 12;


### PR DESCRIPTION
## Summary
- extend `jet.fc` state to hold TON timelock data
- introduce TON withdraw opcodes and handlers
- export new methods in Jet wrapper
- support new fields in deploy script and opcodes

## Testing
- `npm test`