### PR TITLE
Add constructor to init Jet contract state

### DIFF
--- a/contracts/jet.fc
+++ b/contracts/jet.fc
@@ -73,6 +73,29 @@ const int OP_EXEC_ADMIN     = 8;
         );
 }
 
+() constructor() impure {
+        var ds = get_data().begin_parse();
+        cell counters_ref = ds~load_ref();
+        int next_ticket_index = ds~load_uint(64);
+        slice collection_address = ds~load_msg_addr();
+        slice admin_address = ds~load_msg_addr();
+        int price = ds~load_coins();
+        int ref_percent = ds~load_uint(16);
+
+        int jackpot_amount = 0;
+        int locked_jp_coins = 0;
+        int tl_ton_amount = 0;
+        int tl_ton_until = 0;
+        int tl_delay = 0;
+        slice new_admin_address = admin_address;
+        int tl_admin_until = 0;
+
+        store_data(counters_ref, next_ticket_index, collection_address, admin_address,
+                   price, ref_percent, jackpot_amount, locked_jp_coins,
+                   tl_ton_amount, tl_ton_until, tl_delay,
+                   new_admin_address, tl_admin_until);
+}
+
 
 
 


### PR DESCRIPTION
## Summary
- handle missing data on deployment by adding a constructor to `jet.fc`

## Testing
- `npm test`