### PR TITLE
Fix Jet config serialization

### DIFF
--- a/scripts/deployJet.ts
+++ b/scripts/deployJet.ts
@@ -19,6 +19,12 @@ export async function run(provider: NetworkProvider) {
         adminAddress: process.env.ADMIN_ADDRESS || '', // lottery administrator address
         price: 0.25, // ticket price
         refPercent: Number(process.env.REF_PERCENT || '0'), // referral fee in basis points
+        jackpotAmount: process.env.JACKPOT_AMOUNT_TON
+            ? Number(process.env.JACKPOT_AMOUNT_TON)
+            : undefined,
+        timelockDelay: process.env.TIMELOCK_DELAY_SEC_TON
+            ? Number(process.env.TIMELOCK_DELAY_SEC_TON)
+            : undefined,
     };
 
     const jetCode = await compile('Jet');
@@ -30,6 +36,8 @@ export async function run(provider: NetworkProvider) {
                 adminAddress: lotteryConfig.adminAddress,
                 price: lotteryConfig.price,
                 refPercent: lotteryConfig.refPercent,
+                jackpotAmount: lotteryConfig.jackpotAmount,
+                timelockDelay: lotteryConfig.timelockDelay,
             },
             jetCode,
         ),

--- a/wrappers/Jet.ts
+++ b/wrappers/Jet.ts
@@ -21,27 +21,41 @@ export type JetConfig = {
     adminAddress: string;
     price: number;
     refPercent: number;
+    jackpotAmount?: number; // TON
+    timelockDelay?: number; // seconds
 };
 
 export function jetConfigToCell(config: JetConfig): Cell {
-    return beginCell()
-        .storeRef(
-            beginCell()
-            .storeUint(0, 16)
-            .storeUint(0, 16)
-            .storeUint(0, 16)
-            .storeUint(0, 16)
-            .storeUint(0, 16)
-            .storeUint(0, 16)
-            .storeUint(0, 16)
+    const jackpotAmount = config.jackpotAmount ?? 10_000;
+    const timelockDelay = config.timelockDelay ?? 86_400;
+
+    const counters = beginCell()
+        .storeUint(0, 16)
+        .storeUint(0, 16)
+        .storeUint(0, 16)
+        .storeUint(0, 16)
+        .storeUint(0, 16)
+        .storeUint(0, 16)
+        .storeUint(0, 16)
+        .endCell();
+
+    return (
+        beginCell()
+            .storeRef(counters)
+            .storeUint(0, 64) // next_ticket_index
+            .storeAddress(config.collectionAddress)
+            .storeAddress(Address.parse(config.adminAddress))
+            .storeCoins(toNano(config.price))
+            .storeUint(config.refPercent, 16)
+            .storeUint(toNano(jackpotAmount), 128)
+            .storeUint(0, 128) // locked_jp_coins
+            .storeUint(0, 128) // tl_ton_amount
+            .storeUint(0, 64) // tl_ton_until
+            .storeUint(timelockDelay, 64)
+            .storeAddress(Address.parse(config.adminAddress)) // new_admin_address
+            .storeUint(0, 64) // tl_admin_until
             .endCell()
-        )
-        .storeUint(0, 64)
-        .storeAddress(config.collectionAddress)
-        .storeAddress(Address.parse(config.adminAddress))
-        .storeCoins(toNano(config.price))
-        .storeUint(config.refPercent, 16)
-        .endCell()
+    );
 }
 
 export class Jet implements Contract {


### PR DESCRIPTION
## Summary
- add `jackpotAmount` and `timelockDelay` options
- serialize full Jet configuration in `jetConfigToCell`
- allow passing new options when deploying Jet

## Testing
- `npx blueprint build Jet`
- `npm test`
