### PR TITLE
Fix Jet coin cell size

### DIFF
--- a/contracts/jet.fc
+++ b/contracts/jet.fc
@@ -29,9 +29,9 @@ const int OP_EXEC_ADMIN     = 8;
                 ds~load_msg_addr(),
                 ds~load_coins(),
                 ds~load_uint(16),
-                ds~load_uint(128),
-                ds~load_uint(128),
-                ds~load_uint(128),
+                ds~load_coins(),
+                ds~load_coins(),
+                ds~load_coins(),
                 ds~load_uint(64),
                 ds~load_uint(64),
                 ds~load_msg_addr(),
@@ -62,9 +62,9 @@ const int OP_EXEC_ADMIN     = 8;
                 .store_slice(admin_address)
                 .store_coins(price)
                 .store_uint(ref_percent, 16)
-                .store_uint(jackpot_amount, 128)
-                .store_uint(locked_jp_coins, 128)
-                .store_uint(tl_ton_amount, 128)
+                .store_coins(jackpot_amount)
+                .store_coins(locked_jp_coins)
+                .store_coins(tl_ton_amount)
                 .store_uint(tl_ton_until, 64)
                 .store_uint(tl_delay, 64)
                 .store_slice(new_admin_address)

--- a/wrappers/Jet.ts
+++ b/wrappers/Jet.ts
@@ -47,12 +47,12 @@ export function jetConfigToCell(config: JetConfig): Cell {
             .storeAddress(Address.parse(config.adminAddress))
             .storeCoins(toNano(config.price))
             .storeUint(config.refPercent, 16)
-            .storeUint(toNano(jackpotAmount), 128)
-            .storeUint(0, 128) // locked_jp_coins
-            .storeUint(0, 128) // tl_ton_amount
+            .storeCoins(toNano(jackpotAmount))
+            .storeCoins(0) // locked_jp_coins
+            .storeCoins(0) // tl_ton_amount
             .storeUint(0, 64) // tl_ton_until
             .storeUint(timelockDelay, 64)
-            .storeAddress(Address.parse(config.adminAddress)) // new_admin_address
+            .storeAddress(null) // new_admin_address
             .storeUint(0, 64) // tl_admin_until
             .endCell()
     );


### PR DESCRIPTION
## Summary
- use `store_coins` and `load_coins` for jackpot and timelock fields
- update JS wrapper to use `.storeCoins` and null new admin address

## Testing
- `npm install`
- `npm test`