### PR TITLE
Fix wallet address storage in jet contract

### DIFF
--- a/contracts/jet.fc
+++ b/contracts/jet.fc
@@ -38,22 +38,38 @@ const int OP_EXEC_TON     = 12;
     int    ;; tl_ton_until
 ) load_data() inline {
     var ds = get_data().begin_parse();
+    cell counters_ref = ds~load_ref();
+    int next_ticket_index = ds~load_uint(64);
+    slice collection_address = ds~load_msg_addr();
+    slice admin_address = ds~load_msg_addr();
+    int price = ds~load_coins(); ;; ticket_price in jettons
+    int ref_percent = ds~load_uint(8);
+    slice wallet_ref = ds~load_ref().begin_parse();
+    slice token_wallet_address = wallet_ref~load_msg_addr();
+    int jp_amount = ds~load_coins();
+    int locked_jp_tokens = ds~load_coins();
+    int token_balance = ds~load_coins();
+    int tl_usdt_amount = ds~load_coins();
+    int tl_usdt_until = ds~load_uint(64);
+    int tl_delay = ds~load_uint(64);
+    int tl_ton_amount = ds~load_coins();
+    int tl_ton_until = ds~load_uint(64);
     return (
-        ds~load_ref(),
-        ds~load_uint(64),
-        ds~load_msg_addr(),
-        ds~load_msg_addr(),
-        ds~load_coins(), ;; ticket_price in jettons
-        ds~load_uint(8),
-        ds~load_msg_addr(),
-        ds~load_coins(),
-        ds~load_coins(),
-        ds~load_coins(),
-        ds~load_coins(),
-        ds~load_uint(64),
-        ds~load_uint(64),
-        ds~load_coins(),
-        ds~load_uint(64)
+        counters_ref,
+        next_ticket_index,
+        collection_address,
+        admin_address,
+        price,
+        ref_percent,
+        token_wallet_address,
+        jp_amount,
+        locked_jp_tokens,
+        token_balance,
+        tl_usdt_amount,
+        tl_usdt_until,
+        tl_delay,
+        tl_ton_amount,
+        tl_ton_until
     );
 }
 
@@ -82,7 +98,11 @@ int locked_jp_tokens,
             .store_slice(admin_address)
             .store_coins(price)
             .store_uint(ref_percent, 8)
-            .store_slice(token_wallet_address)
+            .store_ref(
+                begin_cell()
+                    .store_slice(token_wallet_address)
+                    .end_cell()
+            )
             .store_coins(jp_amount)
             .store_coins(locked_jp_tokens)
             .store_coins(token_balance)

--- a/wrappers/Jet.ts
+++ b/wrappers/Jet.ts
@@ -41,7 +41,7 @@ export function jetConfigToCell(config: JetConfig): Cell {
             .storeAddress(Address.parse(config.adminAddress))
             .storeCoins(config.price)
             .storeUint(config.refPercent, 8)
-            .storeAddress(null)
+            .storeRef(beginCell().storeAddress(null).endCell())
             .storeCoins(config.jpAmount ?? 0n)
             .storeCoins(config.lockedJpTokens ?? 0n)
             .storeCoins(config.tokenBalance ?? 0n)


### PR DESCRIPTION
## Summary
- keep token wallet address in a separate reference cell in `jet.fc`
- update TypeScript config builder to store a ref for the wallet address

## Testing
- `npm run build` *(fails: blueprint not found)*
- `npm test` *(fails: jest not found)*