### PR TITLE
Fix locked jackpot balance units

### DIFF
--- a/contracts/jet.fc
+++ b/contracts/jet.fc
@@ -173,8 +173,9 @@ int locked_jp_tokens,
 
             throw_unless(400, amount >= price);
             token_balance += amount;
+            ;; jp_amount is stored in whole tokens, convert to microtokens
             if (locked_jp_tokens == 0) {
-                locked_jp_tokens = jp_amount;
+                locked_jp_tokens = jp_amount * jetton_decimals();
             }
 
         int excess = amount - price;
@@ -745,7 +746,8 @@ int locked_jp_tokens,
         int tl_ton_until
     ) = load_data();
 
-    locked_jp_tokens = jp_amount;
+    ;; jp_amount is stored in whole tokens, convert to microtokens
+    locked_jp_tokens = jp_amount * jetton_decimals();
 
     store_data(counters_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, token_wallet_address, jp_amount, locked_jp_tokens, token_balance, tl_usdt_amount, tl_usdt_until, tl_delay, tl_ton_amount, tl_ton_until);
 }


### PR DESCRIPTION
## Summary
- fix jackpot fund lock to use microtokens
- adjust on_bounced logic for microtoken unit

## Testing
- `npm test`