### PR TITLE
Improve withdrawal UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ and new tickets remain fully valid for those rewards.
 
 The `deployJet.ts` script also exposes `withdraw()` and two helper functions,
 `scheduleUSDTWithdrawal()` and `executeUSDTWithdrawal()`, to manage USDT
-withdrawals via the timelock.
+withdrawals via the timelock. Amounts for these helpers are provided in whole
+USDT and TON for convenience.
 
 ## NFT Collection
 The lottery issues unique NFTs for every prize tier. Metadata for each token can be found in the `lottery_metadata` directory and is pinned to IPFS. The collection contract stores the lottery address alongside the owner address, next item index and royalty details. The collection is deployed once and the lottery contract mints the appropriate token when a player wins.

--- a/scripts/deployJet.ts
+++ b/scripts/deployJet.ts
@@ -108,7 +108,8 @@ export async function run(provider: NetworkProvider) {
         rl.close();
 
         if (confirm === 'y' || confirm === 'yes') {
-            await jet.sendScheduleUSDT(provider.sender(), BigInt(amountStr), toNano('0.1'));
+            const amount = BigInt(amountStr) * 1_000_000n;
+            await jet.sendScheduleUSDT(provider.sender(), amount, toNano('0.1'));
             console.log('✅ Withdrawal scheduled');
         } else {
             console.log('Canceled');
@@ -120,12 +121,13 @@ export async function run(provider: NetworkProvider) {
         const ask = (q: string) => new Promise<string>(res => rl.question(q, res));
 
         const amountStr = await ask('Amount to schedule (TON): ');
-        console.log(`Schedule withdrawal of ${amountStr} nanoTON`);
+        console.log(`Schedule withdrawal of ${amountStr} TON`);
         const confirm = (await ask('Confirm schedule? (y/N) ')).toLowerCase();
         rl.close();
 
         if (confirm === 'y' || confirm === 'yes') {
-            await jet.sendScheduleTON(provider.sender(), BigInt(amountStr), toNano('0.1'));
+            const amount = toNano(amountStr);
+            await jet.sendScheduleTON(provider.sender(), amount, toNano('0.1'));
             console.log('✅ Withdrawal scheduled');
         } else {
             console.log('Canceled');


### PR DESCRIPTION
## Summary
- support entering USDT/TON amounts directly when scheduling withdrawals
- document that helper scripts use whole tokens/TON

## Testing
- `npm test --silent`