### PR TITLE
Add wallet wrapper and topup script

### DIFF
--- a/scripts/topupLottery.ts
+++ b/scripts/topupLottery.ts
@@ -1,0 +1,45 @@
+import 'dotenv/config';
+import { Address, beginCell, toNano } from '@ton/core';
+import { NetworkProvider } from '@ton/blueprint';
+import { JettonMaster } from '../wrappers/JettonMaster';
+import { JettonWallet } from '../wrappers/JettonWallet';
+import * as readline from 'readline';
+
+export async function run(provider: NetworkProvider) {
+    const token = process.env.TOKEN_ADDRESS;
+    const lottery = process.env.LOTTERY_ADDRESS;
+    if (!token || token.length === 0) {
+        throw new Error('TOKEN_ADDRESS env variable is missing');
+    }
+    if (!lottery || lottery.length === 0) {
+        throw new Error('LOTTERY_ADDRESS env variable is missing');
+    }
+
+    const master = provider.open(
+        JettonMaster.createFromAddress(Address.parse(token)),
+    );
+
+    const adminTON = provider.sender().address as Address;
+    const adminJet = await master.getWalletAddress(adminTON);
+    const lotteryJet = await master.getWalletAddress(Address.parse(lottery));
+
+    const adminWallet = provider.open(JettonWallet.createFromAddress(adminJet));
+
+    const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+    const ask = (q: string) => new Promise<string>(res => rl.question(q, res));
+    const amountStr = await ask('USDT amount to send: ');
+    rl.close();
+
+    const jettons = BigInt(amountStr) * 1_000_000n;
+
+    await adminWallet.sendTransfer(provider.sender(), {
+        value: toNano('0.31'),
+        jettonAmount: jettons,
+        to: lotteryJet,
+        responseAddress: adminTON,
+        forwardTonAmount: toNano('0.27'),
+        forwardPayload: beginCell().endCell(),
+    });
+
+    console.log('✅ Lottery wallet topped up');
+}

--- a/wrappers/JettonWallet.ts
+++ b/wrappers/JettonWallet.ts
@@ -1,0 +1,45 @@
+import { Address, beginCell, Cell, Contract, ContractProvider, Sender, SendMode } from '@ton/core';
+
+export class JettonWallet implements Contract {
+    constructor(
+        readonly address: Address,
+        readonly init?: { code: Cell; data: Cell },
+    ) {}
+
+    static createFromAddress(address: Address) {
+        return new JettonWallet(address);
+    }
+
+    async sendTransfer(
+        provider: ContractProvider,
+        via: Sender,
+        params: {
+            value: bigint;
+            jettonAmount: bigint;
+            to: Address;
+            forwardTonAmount: bigint;
+            forwardPayload?: Cell;
+            responseAddress?: Address;
+            queryId?: bigint;
+        },
+    ): Promise<void> {
+        const body = beginCell()
+            .storeUint(0xf8a7ea5, 32)
+            .storeUint(params.queryId ?? 0n, 64)
+            .storeCoins(params.jettonAmount)
+            .storeAddress(params.to)
+            .storeAddress(params.responseAddress ?? (via.address as Address))
+            .storeBit(0) // no custom payload
+            .storeCoins(params.forwardTonAmount)
+            .storeBit(1) // forward_payload as ref
+            .storeRef(params.forwardPayload ?? beginCell().endCell())
+            .endCell();
+
+        await provider.internal(via, {
+            value: params.value,
+            sendMode: SendMode.PAY_GAS_SEPARATELY,
+            bounce: true,
+            body,
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- add minimal `JettonWallet` wrapper with `sendTransfer`
- implement `topupLottery` script to fund lottery wallet in USDT

## Testing
- `npm test`