### PR TITLE
Add USDT top-up capability

### DIFF
--- a/contracts/imports/op-codes.fc
+++ b/contracts/imports/op-codes.fc
@@ -30,3 +30,4 @@ int op::take_excess() asm "0xd136d3b3 PUSHINT";
 int op::send_prize() asm "0x5052495a PUSHINT"; ;; 'PRIZ'
 int op::send_reff() asm "0x52454646 PUSHINT"; ;; 'REFF'
 int op::send_usdt() asm "0x55534454 PUSHINT"; ;; 'USDT'
+int op::notify_topup() asm "0x7000 PUSHINT";

--- a/contracts/jet.fc
+++ b/contracts/jet.fc
@@ -19,6 +19,7 @@ const int OP_EXEC_ADMIN     = 9;
 const int OP_CANCEL_ADMIN   = 10;
 const int OP_SCHEDULE_TON = 11;
 const int OP_EXEC_TON     = 12;
+const int OP_TOPUP_USDT   = 13;
 
 (
     cell, ;; counters
@@ -474,6 +475,7 @@ int locked_jp_tokens,
     }
 
     ;; parse op and query_id for admin operations
+    slice admin_body = in_msg_body;
     in_msg_body~load_uint(32);
     int qid = in_msg_body~load_uint(64);
 
@@ -559,6 +561,49 @@ int locked_jp_tokens,
                    token_wallet_address, jp_amount, locked_jp_tokens,
                    token_balance, tl_usdt_amount, tl_usdt_until, tl_delay, tl_ton_amount, tl_ton_until);
         return ();
+    }
+
+    if (op == OP_TOPUP_USDT) {
+        slice orig_body = admin_body;
+        throw_unless(401, equal_slices(sender_address, admin_address));
+        throw_unless(400, msg_value >= 30000000);
+        int amount = in_msg_body~load_coins();
+        try {
+            token_balance += amount;
+
+            store_data(counters_ref, next_ticket_index, collection_address,
+                       admin_address, price, ref_percent,
+                       token_wallet_address, jp_amount, locked_jp_tokens,
+                       token_balance, tl_usdt_amount, tl_usdt_until, tl_delay,
+                       tl_ton_amount, tl_ton_until);
+
+            var nmsg = begin_cell()
+                .store_uint(flag::bounce(), 6)
+                .store_slice(sender_address)
+                .store_coins(0)
+                .store_uint(0, 1 + 4 + 4 + 64 + 32 + 1 + 1)
+                .store_uint(op::notify_topup(), 32)
+                .store_uint(qid, 64)
+                .store_uint(amount, 128)
+                .end_cell();
+            send_raw_message(nmsg, 64);
+            return ();
+        } catch (_) {
+            int ramount = 0;
+            if (equal_slices(sender_address, admin_address) & (msg_value >= 30000000)) {
+                slice rb = orig_body;
+                rb~load_uint(32);
+                rb~load_uint(64);
+                ramount = rb~load_coins();
+            }
+            token_balance = token_balance - ramount;
+            store_data(counters_ref, next_ticket_index, collection_address,
+                       admin_address, price, ref_percent,
+                       token_wallet_address, jp_amount, locked_jp_tokens,
+                       token_balance, tl_usdt_amount, tl_usdt_until, tl_delay,
+                       tl_ton_amount, tl_ton_until);
+            return();
+        }
     }
 
 

--- a/scripts/topUpUSDT.ts
+++ b/scripts/topUpUSDT.ts
@@ -1,0 +1,19 @@
+import { toNano, Address } from '@ton/core';
+import { NetworkProvider } from '@ton/blueprint';
+import { Jet } from '../wrappers/Jet';
+import * as readline from 'readline';
+
+export async function run(provider: NetworkProvider) {
+    const amountStr = await new Promise<string>(res => {
+        const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+        rl.question('Amount to top-up (whole USDT): ', ans => { rl.close(); res(ans); });
+    });
+
+    const jettons = BigInt(amountStr) * 1_000_000n;
+    const jet = provider.open(
+        Jet.createFromAddress(Address.parse(process.env.LOTTERY_ADDRESS || '')),
+    );
+
+    await jet.sendTopUpUSDT(provider.sender(), jettons, toNano('0.06'));
+    console.log(`✅ Topped up ${amountStr} USDT`);
+}

--- a/tests/admin.topup.spec.ts
+++ b/tests/admin.topup.spec.ts
@@ -1,0 +1,23 @@
+import { JetContract } from '../helpers';
+import { toNano } from '@ton/core';
+import '@ton/test-utils';
+
+describe('jet.fc – admin top-up', () => {
+  it('increases token balance', async () => {
+    const jet = await JetContract.deploy();
+    const before = await jet.contract.getFullData();
+    const r = await jet.contract.sendTopUpUSDT(jet.deployer.getSender(), 1_000_000n, toNano('0.06'));
+    expect(r.transactions).toHaveTransaction({ exitCode: 0 });
+    const after = await jet.contract.getFullData();
+    expect(after.tokenBalance - before.tokenBalance).toBe(1_000_000n);
+    expect(after.nextIndex).toEqual(before.nextIndex);
+    expect(after.counters.hash()).toEqual(before.counters.hash());
+  });
+
+  it('rejects non-admin', async () => {
+    const jet = await JetContract.deploy();
+    const user = await jet.blockchain.treasury('usr');
+    const res = await jet.contract.sendTopUpUSDT(user.getSender(), 1_000_000n, toNano('0.06'));
+    expect(res.transactions).toHaveTransaction({ exitCode: 401 });
+  });
+});

--- a/wrappers/Jet.ts
+++ b/wrappers/Jet.ts
@@ -1,5 +1,5 @@
 import { Address, beginCell, Cell, Contract, contractAddress, ContractProvider, Sender, SendMode } from '@ton/core';
-import { OP_SCHEDULE_USDT, OP_EXEC_USDT, OP_SCHEDULE_ADMIN, OP_EXEC_ADMIN, OP_CANCEL_ADMIN, OP_SCHEDULE_TON, OP_EXEC_TON } from "./opcodes";
+import { OP_SCHEDULE_USDT, OP_EXEC_USDT, OP_SCHEDULE_ADMIN, OP_EXEC_ADMIN, OP_CANCEL_ADMIN, OP_SCHEDULE_TON, OP_EXEC_TON, OP_TOPUP_USDT } from "./opcodes";
 
 export type JetConfig = {
     collectionAddress: Address;
@@ -131,6 +131,19 @@ export class Jet implements Contract {
         const body = beginCell()
             .storeUint(OP_EXEC_TON, 32)
             .storeUint(0, 64)
+            .endCell();
+        await provider.internal(via, {
+            value,
+            sendMode: SendMode.PAY_GAS_SEPARATELY,
+            body,
+        });
+    }
+
+    async sendTopUpUSDT(provider: ContractProvider, via: Sender, amount: bigint, value: bigint) {
+        const body = beginCell()
+            .storeUint(OP_TOPUP_USDT, 32)
+            .storeUint(0, 64)
+            .storeCoins(amount)
             .endCell();
         await provider.internal(via, {
             value,

--- a/wrappers/opcodes.ts
+++ b/wrappers/opcodes.ts
@@ -7,3 +7,4 @@ export const OP_EXEC_ADMIN = 9;
 export const OP_CANCEL_ADMIN = 10;
 export const OP_SCHEDULE_TON = 11;
 export const OP_EXEC_TON = 12;
+export const OP_TOPUP_USDT = 13;


### PR DESCRIPTION
## Summary
- allow admin top-ups with new `OP_TOPUP_USDT` opcode
- expose opcode to JS wrappers and add helper `sendTopUpUSDT`
- emit `op::notify_topup` for indexers
- provide interactive `topUpUSDT.ts` script
- test top-up behavior

## Testing
- `npm test`