### PR TITLE
Enable unlimited USDT top‑ups for admin

### DIFF
--- a/contracts/jet.fc
+++ b/contracts/jet.fc
@@ -171,12 +171,32 @@ int locked_jp_tokens,
 
             throw_unless(400, msg_value >= min_ticket_value());
 
-            throw_unless(400, amount >= price);
             token_balance += amount;
             ;; jp_amount is stored in whole tokens, convert to microtokens
             if (locked_jp_tokens == 0) {
                 locked_jp_tokens = jp_amount * jetton_decimals();
             }
+
+            ;; check for admin top-up payload
+            int topup = 0;
+            if (slice_bits(fwd_payload) >= 32) {
+                int op_top = fwd_payload.preload_uint(32);
+                if (op_top == op::notify_topup()) {
+                    fwd_payload~load_uint(32);
+                    end_parse(fwd_payload);
+                    topup = 1;
+                }
+            }
+
+            if (topup == 1) {
+                store_data(counters_ref, next_ticket_index, collection_address,
+                           admin_address, price, ref_percent,
+                           token_wallet_address, jp_amount, locked_jp_tokens,
+                           token_balance, tl_usdt_amount, tl_usdt_until, tl_delay, tl_ton_amount, tl_ton_until);
+                return();
+            }
+
+            throw_unless(400, amount >= price);
 
         int excess = amount - price;
         if (excess > 0) {

--- a/scripts/topUpUSDT.ts
+++ b/scripts/topUpUSDT.ts
@@ -2,6 +2,8 @@ import { toNano, Address } from '@ton/core';
 import { NetworkProvider } from '@ton/blueprint';
 import { JettonMaster } from '../wrappers/JettonMaster';
 import { JettonWallet } from '../wrappers/JettonWallet';
+import { beginCell } from '@ton/core';
+import { OP_NOTIFY_TOPUP } from '../wrappers/opcodes';
 import * as readline from 'readline';
 
 export async function run(provider: NetworkProvider) {
@@ -29,11 +31,14 @@ export async function run(provider: NetworkProvider) {
         throw new Error('Insufficient USDT balance');
     }
 
+    // mark transfer as a top-up so the lottery keeps full amount
+    const payload = beginCell().storeUint(OP_NOTIFY_TOPUP, 32).endCell();
     await adminWallet.sendTransfer(provider.sender(), {
         to: lotteryWalletAddr,
         amount: jettons,
         value: toNano('0.31'),
         forwardTon: toNano('0.3'),
+        payload,
     });
     console.log(`✅ Topped up ${amountStr} USDT`);
 }

--- a/wrappers/JettonWallet.ts
+++ b/wrappers/JettonWallet.ts
@@ -28,19 +28,25 @@ export class JettonWallet implements Contract {
             amount: bigint;
             value: bigint;
             forwardTon?: bigint;
+            payload?: Cell;
             queryID?: bigint;
             responseAddress?: Address;
         },
     ) {
         const response = args.responseAddress ?? via.address?.();
         if (!response) throw new Error('Sender address required');
-        const body = beginCell()
+        const bodyBuilder = beginCell()
             .storeUint(0xf8a7ea5, 32) // jetton_transfer op
             .storeUint(args.queryID ?? 0n, 64)
             .storeCoins(args.amount)
             .storeAddress(args.to)
             .storeAddress(response)
-            .storeBit(0) // no custom payload
+        if (args.payload) {
+            bodyBuilder.storeBit(1).storeRef(args.payload);
+        } else {
+            bodyBuilder.storeBit(0);
+        }
+        const body = bodyBuilder
             .storeCoins(args.forwardTon ?? 0n)
             .storeBit(0) // empty forward payload
             .endCell();

--- a/wrappers/opcodes.ts
+++ b/wrappers/opcodes.ts
@@ -8,3 +8,4 @@ export const OP_CANCEL_ADMIN = 10;
 export const OP_SCHEDULE_TON = 11;
 export const OP_EXEC_TON = 12;
 export const OP_TOPUP_USDT = 13;
+export const OP_NOTIFY_TOPUP = 0x7000;


### PR DESCRIPTION
## Summary
- handle `notify_topup` payload so admin can deposit any jetton amount
- expose new `OP_NOTIFY_TOPUP` code
- allow sending custom payloads from `JettonWallet`
- use the new payload in `topUpUSDT.ts`

## Testing
- `npm install`
- `npm test`