### PR TITLE
Fix Jetton topup notification forwarding

### DIFF
--- a/scripts/deployJet.ts
+++ b/scripts/deployJet.ts
@@ -180,7 +180,7 @@ export async function run(provider: NetworkProvider) {
             amount: jettons,
             value: toNano('0.55'),
             forwardTon: toNano('0.3'),
-            payload,
+            forwardPayload: payload,
         });
         console.log(`✅ Topped up ${amountStr} USDT`);
     }

--- a/wrappers/JettonWallet.ts
+++ b/wrappers/JettonWallet.ts
@@ -29,6 +29,7 @@ export class JettonWallet implements Contract {
             value: bigint;
             forwardTon?: bigint;
             payload?: Cell;
+            forwardPayload?: Cell;
             queryID?: bigint;
             responseAddress?: Address;
         },
@@ -48,7 +49,8 @@ export class JettonWallet implements Contract {
         }
         const body = bodyBuilder
             .storeCoins(args.forwardTon ?? 0n)
-            .storeBit(0) // empty forward payload
+            .storeBit(args.forwardPayload ? 1 : 0)
+            .storeMaybeRef(args.forwardPayload)
             .endCell();
 
         await provider.internal(via, {


### PR DESCRIPTION
## Summary
- add optional forward payload parameter to Jetton wallet transfer
- use forward payload when topping up USDT in deploy script

## Testing
- `npm test`