### PR TITLE
Avoid cell overflow by splitting lottery data

### DIFF
--- a/contracts/jet.fc
+++ b/contracts/jet.fc
@@ -46,14 +46,16 @@ const int OP_EXEC_TON     = 12;
     int ref_percent = ds~load_uint(8);
     slice wallet_ref = ds~load_ref().begin_parse();
     slice token_wallet_address = wallet_ref~load_msg_addr();
-    int jp_amount = ds~load_coins();
-    int locked_jp_tokens = ds~load_coins();
-    int token_balance = ds~load_coins();
-    int tl_usdt_amount = ds~load_coins();
-    int tl_usdt_until = ds~load_uint(64);
-    int tl_delay = ds~load_uint(64);
-    int tl_ton_amount = ds~load_coins();
-    int tl_ton_until = ds~load_uint(64);
+
+    slice extra_ref = ds~load_ref().begin_parse();
+    int jp_amount = extra_ref~load_coins();
+    int locked_jp_tokens = extra_ref~load_coins();
+    int token_balance = extra_ref~load_coins();
+    int tl_usdt_amount = extra_ref~load_coins();
+    int tl_usdt_until = extra_ref~load_uint(64);
+    int tl_delay = extra_ref~load_uint(64);
+    int tl_ton_amount = extra_ref~load_coins();
+    int tl_ton_until = extra_ref~load_uint(64);
     return (
         counters_ref,
         next_ticket_index,
@@ -90,6 +92,17 @@ int locked_jp_tokens,
     int tl_ton_amount,
     int tl_ton_until
 ) impure inline {
+    cell extra = begin_cell()
+        .store_coins(jp_amount)
+        .store_coins(locked_jp_tokens)
+        .store_coins(token_balance)
+        .store_coins(tl_usdt_amount)
+        .store_uint(tl_usdt_until, 64)
+        .store_uint(tl_delay, 64)
+        .store_coins(tl_ton_amount)
+        .store_uint(tl_ton_until, 64)
+        .end_cell();
+
     set_data(
         begin_cell()
             .store_ref(counters_ref)
@@ -103,14 +116,7 @@ int locked_jp_tokens,
                     .store_slice(token_wallet_address)
                     .end_cell()
             )
-            .store_coins(jp_amount)
-            .store_coins(locked_jp_tokens)
-            .store_coins(token_balance)
-            .store_coins(tl_usdt_amount)
-            .store_uint(tl_usdt_until, 64)
-            .store_uint(tl_delay, 64)
-            .store_coins(tl_ton_amount)
-            .store_uint(tl_ton_until, 64)
+            .store_ref(extra)
             .end_cell()
     );
 }

--- a/wrappers/Jet.ts
+++ b/wrappers/Jet.ts
@@ -20,6 +20,18 @@ export type JetConfig = {
 };
 
 export function jetConfigToCell(config: JetConfig): Cell {
+    const walletRef = beginCell().storeAddress(config.tokenAddress).endCell();
+    const extraRef = beginCell()
+        .storeCoins(config.jpAmount ?? 0n)
+        .storeCoins(config.lockedJpTokens ?? 0n)
+        .storeCoins(config.tokenBalance ?? 0n)
+        .storeCoins(config.tlUsdtAmount ?? 0n)
+        .storeUint(config.tlUsdtUntil ?? 0n, 64)
+        .storeUint(config.tlDelay ?? 0n, 64)
+        .storeCoins(config.tlTonAmount ?? 0n)
+        .storeUint(config.tlTonUntil ?? 0n, 64)
+        .endCell();
+
     return (
         beginCell()
             .storeRef(
@@ -36,20 +48,12 @@ export function jetConfigToCell(config: JetConfig): Cell {
                     .endCell(),
             )
             .storeUint(0, 64)
-            // collection and token wallet addresses are initially empty to fit 1023-bit limit
             .storeAddress(config.collectionAddress)
             .storeAddress(Address.parse(config.adminAddress))
             .storeCoins(config.price)
             .storeUint(config.refPercent, 8)
-            .storeRef(beginCell().storeAddress(null).endCell())
-            .storeCoins(config.jpAmount ?? 0n)
-            .storeCoins(config.lockedJpTokens ?? 0n)
-            .storeCoins(config.tokenBalance ?? 0n)
-            .storeCoins(config.tlUsdtAmount ?? 0n)
-            .storeUint(config.tlUsdtUntil ?? 0n, 64)
-            .storeUint(config.tlDelay ?? 0n, 64)
-            .storeCoins(config.tlTonAmount ?? 0n)
-            .storeUint(config.tlTonUntil ?? 0n, 64)
+            .storeRef(walletRef)
+            .storeRef(extraRef)
             .endCell()
     );
 }


### PR DESCRIPTION
## Summary
- prevent cell overflow in the Jet contract by storing part of the data in a second cell
- update TypeScript config builder to follow the new layout

## Testing
- `npm test`