### PR TITLE
Fix data cell overflow by moving timelock fields to ref

### DIFF
--- a/contracts/jet.fc
+++ b/contracts/jet.fc
@@ -22,8 +22,11 @@ const int OP_EXEC_ADMIN     = 8;
         int    ;; admin unlock timestamp
 ) load_data() inline {
         var ds = get_data().begin_parse();
+        cell counters_ref = ds~load_ref();
+        cell tl_ref = ds~load_ref();
+        var tl = tl_ref.begin_parse();
         return (
-                ds~load_ref(),
+                counters_ref,
                 ds~load_uint(64),
                 ds~load_msg_addr(),
                 ds~load_msg_addr(),
@@ -31,11 +34,11 @@ const int OP_EXEC_ADMIN     = 8;
                 ds~load_uint(16),
                 ds~load_coins(),
                 ds~load_coins(),
-                ds~load_coins(),
-                ds~load_uint(64),
-                ds~load_uint(64),
-                ds~load_msg_addr(),
-                ds~load_uint(64)
+                tl~load_coins(),
+                tl~load_uint(64),
+                tl~load_uint(64),
+                tl~load_msg_addr(),
+                tl~load_uint(64)
         );
 }
 
@@ -54,9 +57,18 @@ const int OP_EXEC_ADMIN     = 8;
         slice new_admin_address,
         int tl_admin_until
 ) impure inline {
+        cell tl_ref = begin_cell()
+                .store_coins(tl_ton_amount)
+                .store_uint(tl_ton_until, 64)
+                .store_uint(tl_delay, 64)
+                .store_slice(new_admin_address)
+                .store_uint(tl_admin_until, 64)
+                .end_cell();
+
         set_data(
                 begin_cell()
                 .store_ref(counters_ref)
+                .store_ref(tl_ref)
                 .store_uint(next_ticket_index, 64)
                 .store_slice(collection_address)
                 .store_slice(admin_address)
@@ -64,11 +76,6 @@ const int OP_EXEC_ADMIN     = 8;
                 .store_uint(ref_percent, 16)
                 .store_coins(jackpot_amount)
                 .store_coins(locked_jp_coins)
-                .store_coins(tl_ton_amount)
-                .store_uint(tl_ton_until, 64)
-                .store_uint(tl_delay, 64)
-                .store_slice(new_admin_address)
-                .store_uint(tl_admin_until, 64)
                 .end_cell()
         );
 }

--- a/tests/Jet.spec.ts
+++ b/tests/Jet.spec.ts
@@ -42,6 +42,15 @@ describe('Jet', () => {
                         .storeUint(0, 16)
                         .endCell(),
                 )
+                .storeRef(
+                    beginCell()
+                        .storeCoins(0)
+                        .storeUint(0, 64)
+                        .storeUint(tlDelayTon, 64)
+                        .storeAddress(null)
+                        .storeUint(0, 64)
+                        .endCell(),
+                )
                 .storeUint(0, 64)
                 .storeAddress(collection.address)
                 .storeAddress(deployer.address)
@@ -49,10 +58,7 @@ describe('Jet', () => {
                 .storeUint(0, 16)
                 .storeUint(jpAmount, 128)
                 .storeUint(0n, 128)
-                .storeUint(0n, 128)
-                .storeUint(0n, 64)
-                .storeUint(tlDelayTon, 64)
                 .endCell(),
-        ).toThrow();
+        ).not.toThrow();
     });
 });

--- a/wrappers/Jet.ts
+++ b/wrappers/Jet.ts
@@ -39,9 +39,18 @@ export function jetConfigToCell(config: JetConfig): Cell {
         .storeUint(0, 16)
         .endCell();
 
+    const timelock = beginCell()
+        .storeCoins(0) // tl_ton_amount
+        .storeUint(0, 64) // tl_ton_until
+        .storeUint(timelockDelay, 64)
+        .storeAddress(null) // new_admin_address
+        .storeUint(0, 64) // tl_admin_until
+        .endCell();
+
     return (
         beginCell()
             .storeRef(counters)
+            .storeRef(timelock)
             .storeUint(0, 64) // next_ticket_index
             .storeAddress(config.collectionAddress)
             .storeAddress(Address.parse(config.adminAddress))
@@ -49,11 +58,6 @@ export function jetConfigToCell(config: JetConfig): Cell {
             .storeUint(config.refPercent, 16)
             .storeCoins(toNano(jackpotAmount))
             .storeCoins(0) // locked_jp_coins
-            .storeCoins(0) // tl_ton_amount
-            .storeUint(0, 64) // tl_ton_until
-            .storeUint(timelockDelay, 64)
-            .storeAddress(null) // new_admin_address
-            .storeUint(0, 64) // tl_admin_until
             .endCell()
     );
 }


### PR DESCRIPTION
## Summary
- avoid data cell overflow in Jet contract by moving timelock fields into a
  separate referenced cell
- update wrapper to generate new layout
- adjust test expecting the cell to build successfully

## Testing
- `npm test --silent`