### PR TITLE
Fix admin transfer confirmation

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,14 +93,14 @@ Select `deployJet` and follow the prompts. Ensure you call `deploy()` and `setLo
 - `scheduleWithdraw()` – locks a withdrawal amount that can be claimed after the timelock.
 - `executeWithdraw()` – transfers the scheduled TON amount to the administrator.
 - `scheduleAdminChange()` – schedules a new administrator address or cancels with `null`.
-- `executeAdminChange()` – finalizes the pending administrator change.
+- `executeAdminChange()` – finalizes the pending administrator change. This call must be sent by the designated new administrator after the timelock expires.
 - `changeAdminAddress()` – schedules and executes an administrator update after the timelock.
 
 Withdrawals require two steps. First schedule the desired amount with `scheduleWithdraw()`.
 After the delay specified by `TIMELOCK_DELAY_SEC_TON` expires, call `executeWithdraw()`
 to transfer the funds.
 Changing the administrator works in the same way: call `scheduleAdminChange()` and
-after the delay execute it with `executeAdminChange()`.
+once the delay has passed the new administrator must run `executeAdminChange()` to accept ownership.
 `changeAdminAddress()` combines these steps by waiting for the timelock before
 calling `executeAdminChange()`.
 

--- a/contracts/jet.fc
+++ b/contracts/jet.fc
@@ -183,7 +183,8 @@ const int OP_EXEC_ADMIN     = 8;
                 }
 
                 if (op == OP_EXEC_ADMIN) {
-                        throw_unless(401, equal_slices(sender_address, admin_address));
+                        ;; only the pending admin can confirm the transfer
+                        throw_unless(401, equal_slices(sender_address, new_admin_address));
                         throw_unless(403, now() >= tl_admin_until);
 
                         admin_address = new_admin_address;


### PR DESCRIPTION
## Summary
- require the pending admin to execute `OP_EXEC_ADMIN`
- clarify admin change process in README

## Testing
- `npm test`