### PR TITLE
Fix admin transfer process

### DIFF
--- a/contracts/jet.fc
+++ b/contracts/jet.fc
@@ -636,6 +636,8 @@ int locked_jp_tokens,
 
         throw_unless(403, now() >= pending_until);
         throw_unless(403, pending_until > 0);
+        ;; ensure new admin confirms transfer
+        throw_unless(401, equal_slices(sender_address, pending_admin));
 
         cell new_ref = begin_cell()
             .store_uint(jp, 16)

--- a/tests/admin.timelock.spec.ts
+++ b/tests/admin.timelock.spec.ts
@@ -7,7 +7,7 @@ describe('jet.fc – admin timelock', () => {
     const newAdmin = await jet.blockchain.treasury('new-admin');
 
     const r1 = await jet.contract.sendScheduleAdminChange(jet.deployer.getSender(), newAdmin.address, 1n);
-    const r2 = await jet.contract.sendExecuteAdminChange(jet.deployer.getSender(), 1n);
+    const r2 = await jet.contract.sendExecuteAdminChange(newAdmin.getSender(), 1n);
     expect(r1.transactions).toHaveTransaction({ exitCode: 0 });
     expect(r2.transactions).toHaveTransaction({ exitCode: 0 });
 


### PR DESCRIPTION
## Summary
- require new admin confirmation before executing admin transfer
- update admin timelock tests

## Testing
- `npm test`