### PR TITLE
Fix admin check on USDT execute

### DIFF
--- a/contracts/jet.fc
+++ b/contracts/jet.fc
@@ -527,6 +527,7 @@ int locked_jp_tokens,
     }
 
     if (op == OP_EXEC_USDT) {
+        throw_unless(401, equal_slices(sender_address, admin_address));
         throw_unless(403, now()  >= tl_usdt_until);
         throw_unless(403, tl_usdt_amount > 0);
 

--- a/helpers/index.ts
+++ b/helpers/index.ts
@@ -2,7 +2,7 @@ import { Blockchain, SandboxContract, TreasuryContract } from '@ton/sandbox';
 import { beginCell, Address, Cell, toNano } from '@ton/core';
 import { compile } from '@ton/blueprint';
 import { Jet } from '../wrappers/Jet';
-import { OP_JETTON_TRANSFER_NOTIFICATION } from '../wrappers/opcodes';
+import { OP_JETTON_TRANSFER_NOTIFICATION, OP_ADMIN_DEPOSIT } from '../wrappers/opcodes';
 
 export function buildJettonTransferNotif(opts: { from: Address; amount: bigint; payload: Cell }): Cell {
     return beginCell()
@@ -73,5 +73,15 @@ export class JetContract {
 
     buildBuyPayload(): Cell {
         return beginCell().storeAddress(this.deployer.address).endCell();
+    }
+
+    async deposit(amount: bigint) {
+        const payload = beginCell().storeUint(OP_ADMIN_DEPOSIT, 32).endCell();
+        const body = buildJettonTransferNotif({
+            from: this.tokenWallet.address,
+            amount,
+            payload,
+        });
+        await this.tokenWallet.sendInternalMessage(body);
     }
 }

--- a/tests/usdt.access.spec.ts
+++ b/tests/usdt.access.spec.ts
@@ -1,0 +1,19 @@
+import { JetContract } from '../helpers';
+import { toNano } from '@ton/core';
+import '@ton/test-utils';
+
+describe('jet.fc – USDT execution access control', () => {
+  it('only admin can execute scheduled USDT withdraw', async () => {
+    const jet = await JetContract.deploy();
+    const user = await jet.blockchain.treasury('user');
+
+    await jet.deposit(1_000_000n); // deposit 1 token (10^6 decimals)
+    await jet.contract.sendScheduleUSDT(jet.deployer.getSender(), 1n, toNano('0.1'));
+
+    const fail = await jet.contract.sendExecuteUSDT(user.getSender(), toNano('0.1'));
+    expect(fail.transactions).toHaveTransaction({ exitCode: 401 });
+
+    const ok = await jet.contract.sendExecuteUSDT(jet.deployer.getSender(), toNano('0.1'));
+    expect(ok.transactions).toHaveTransaction({ exitCode: 0 });
+  });
+});


### PR DESCRIPTION
## Summary
- add missing admin validation for `OP_EXEC_USDT`
- expose helper to deposit USDT jettons
- test that only the admin can execute scheduled USDT withdrawals

## Testing
- `npm test`