### PR TITLE
Refactor admin timelock storage

### DIFF
--- a/contracts/jet.fc
+++ b/contracts/jet.fc
@@ -40,7 +40,7 @@ const int OP_EXEC_TON     = 12;
 ) load_data() inline {
     var ds = get_data().begin_parse();
     cell counters_ref = ds~load_ref();
-    cell admin_ref = ds~load_ref();
+    cell admin_transfer_ref = ds~load_ref();
     int next_ticket_index = ds~load_uint(64);
     slice collection_address = ds~load_msg_addr();
     slice admin_address = ds~load_msg_addr();
@@ -60,7 +60,7 @@ const int OP_EXEC_TON     = 12;
     int tl_ton_until = extra_ref~load_uint(64);
     return (
         counters_ref,
-        admin_ref,
+        admin_transfer_ref,
         next_ticket_index,
         collection_address,
         admin_address,
@@ -80,7 +80,7 @@ const int OP_EXEC_TON     = 12;
 
 () store_data(
 cell counters_ref,
-cell admin_ref,
+cell admin_transfer_ref,
 int next_ticket_index,
 slice collection_address,
 slice admin_address,
@@ -110,7 +110,7 @@ int locked_jp_tokens,
     set_data(
         begin_cell()
             .store_ref(counters_ref)
-            .store_ref(admin_ref)
+            .store_ref(admin_transfer_ref)
             .store_uint(next_ticket_index, 64)
             .store_slice(collection_address)
             .store_slice(admin_address)
@@ -144,7 +144,7 @@ int locked_jp_tokens,
     slice sender_address = cs~load_msg_addr();
     var (
         cell counters_ref,
-        cell admin_ref,
+        cell admin_transfer_ref,
         int next_ticket_index,
         slice collection_address,
         slice admin_address,
@@ -197,7 +197,7 @@ int locked_jp_tokens,
             }
 
         if (deposit == 1) {
-                store_data(counters_ref, admin_ref, next_ticket_index, collection_address,
+                store_data(counters_ref, admin_transfer_ref, next_ticket_index, collection_address,
                            admin_address, price, ref_percent,
                            token_wallet_address, jp_amount, locked_jp_tokens,
                            token_balance, tl_usdt_amount, tl_usdt_until, tl_delay,
@@ -324,7 +324,7 @@ int locked_jp_tokens,
                     .store_uint(low, 16)
                     .store_uint(mini, 16)
                     .end_cell();
-                store_data(new_ref, admin_ref, next_ticket_index, collection_address,
+                store_data(new_ref, admin_transfer_ref, next_ticket_index, collection_address,
                            admin_address, price, ref_percent,
                            token_wallet_address, jp_amount, locked_jp_tokens,
                            token_balance, tl_usdt_amount, tl_usdt_until, tl_delay, tl_ton_amount, tl_ton_until);
@@ -348,7 +348,7 @@ int locked_jp_tokens,
                     .store_uint(low, 16)
                     .store_uint(mini, 16)
                     .end_cell();
-                store_data(new_ref, admin_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, token_wallet_address, jp_amount, locked_jp_tokens, token_balance, tl_usdt_amount, tl_usdt_until, tl_delay, tl_ton_amount, tl_ton_until);
+                store_data(new_ref, admin_transfer_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, token_wallet_address, jp_amount, locked_jp_tokens, token_balance, tl_usdt_amount, tl_usdt_until, tl_delay, tl_ton_amount, tl_ton_until);
                 return();
             }
         }
@@ -371,7 +371,7 @@ int locked_jp_tokens,
                     .store_uint(low, 16)
                     .store_uint(mini, 16)
                     .end_cell();
-                store_data(new_ref, admin_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, token_wallet_address, jp_amount, locked_jp_tokens, token_balance, tl_usdt_amount, tl_usdt_until, tl_delay, tl_ton_amount, tl_ton_until);
+                store_data(new_ref, admin_transfer_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, token_wallet_address, jp_amount, locked_jp_tokens, token_balance, tl_usdt_amount, tl_usdt_until, tl_delay, tl_ton_amount, tl_ton_until);
                 return();
             }
         }
@@ -394,7 +394,7 @@ int locked_jp_tokens,
                     .store_uint(low, 16)
                     .store_uint(mini, 16)
                     .end_cell();
-                store_data(new_ref, admin_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, token_wallet_address, jp_amount, locked_jp_tokens, token_balance, tl_usdt_amount, tl_usdt_until, tl_delay, tl_ton_amount, tl_ton_until);
+                store_data(new_ref, admin_transfer_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, token_wallet_address, jp_amount, locked_jp_tokens, token_balance, tl_usdt_amount, tl_usdt_until, tl_delay, tl_ton_amount, tl_ton_until);
                 return();
             }
         }
@@ -417,7 +417,7 @@ int locked_jp_tokens,
                     .store_uint(low, 16)
                     .store_uint(mini, 16)
                     .end_cell();
-                store_data(new_ref, admin_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, token_wallet_address, jp_amount, locked_jp_tokens, token_balance, tl_usdt_amount, tl_usdt_until, tl_delay, tl_ton_amount, tl_ton_until);
+                store_data(new_ref, admin_transfer_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, token_wallet_address, jp_amount, locked_jp_tokens, token_balance, tl_usdt_amount, tl_usdt_until, tl_delay, tl_ton_amount, tl_ton_until);
                 return();
             }
         }
@@ -440,7 +440,7 @@ int locked_jp_tokens,
                     .store_uint(low, 16)
                     .store_uint(mini, 16)
                     .end_cell();
-                store_data(new_ref, admin_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, token_wallet_address, jp_amount, locked_jp_tokens, token_balance, tl_usdt_amount, tl_usdt_until, tl_delay, tl_ton_amount, tl_ton_until);
+                store_data(new_ref, admin_transfer_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, token_wallet_address, jp_amount, locked_jp_tokens, token_balance, tl_usdt_amount, tl_usdt_until, tl_delay, tl_ton_amount, tl_ton_until);
                 return();
             }
         }
@@ -463,7 +463,7 @@ int locked_jp_tokens,
                     .store_uint(low, 16)
                     .store_uint(mini, 16)
                     .end_cell();
-                store_data(new_ref, admin_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, token_wallet_address, jp_amount, locked_jp_tokens, token_balance, tl_usdt_amount, tl_usdt_until, tl_delay, tl_ton_amount, tl_ton_until);
+                store_data(new_ref, admin_transfer_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, token_wallet_address, jp_amount, locked_jp_tokens, token_balance, tl_usdt_amount, tl_usdt_until, tl_delay, tl_ton_amount, tl_ton_until);
                 return();
             }
         }
@@ -472,7 +472,7 @@ int locked_jp_tokens,
 
         send_winning(0, qid, player_address, 7, collection_address, 7, token_wallet_address);
 
-        store_data(counters_ref, admin_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, token_wallet_address, jp_amount, locked_jp_tokens, token_balance, tl_usdt_amount, tl_usdt_until, tl_delay, tl_ton_amount, tl_ton_until);
+        store_data(counters_ref, admin_transfer_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, token_wallet_address, jp_amount, locked_jp_tokens, token_balance, tl_usdt_amount, tl_usdt_until, tl_delay, tl_ton_amount, tl_ton_until);
 
         return();
         }
@@ -491,7 +491,7 @@ int locked_jp_tokens,
                 } catch (_) {
                 }
             }
-            store_data(counters_ref, admin_ref, next_ticket_index, collection_address,
+            store_data(counters_ref, admin_transfer_ref, next_ticket_index, collection_address,
                        admin_address, price, ref_percent,
                        token_wallet_address, jp_amount, locked_jp_tokens,
                        token_balance, tl_usdt_amount, tl_usdt_until, tl_delay, tl_ton_amount, tl_ton_until);
@@ -519,7 +519,7 @@ int locked_jp_tokens,
             tl_usdt_until  = now() + tl_delay;
         }
 
-        store_data(counters_ref, admin_ref, next_ticket_index, collection_address,
+        store_data(counters_ref, admin_transfer_ref, next_ticket_index, collection_address,
                    admin_address, price, ref_percent,
                    token_wallet_address, jp_amount, locked_jp_tokens,
                    token_balance, tl_usdt_amount, tl_usdt_until, tl_delay, tl_ton_amount, tl_ton_until);
@@ -539,7 +539,7 @@ int locked_jp_tokens,
         tl_usdt_amount  = 0;
         tl_usdt_until   = 0;
 
-        store_data(counters_ref, admin_ref, next_ticket_index, collection_address,
+        store_data(counters_ref, admin_transfer_ref, next_ticket_index, collection_address,
                    admin_address, price, ref_percent,
                    token_wallet_address, jp_amount, locked_jp_tokens,
                    token_balance, tl_usdt_amount, tl_usdt_until, tl_delay, tl_ton_amount, tl_ton_until);
@@ -554,7 +554,7 @@ int locked_jp_tokens,
 
         tl_ton_amount = req;
         tl_ton_until  = (req == 0) ? 0 : now() + tl_delay;
-        store_data(counters_ref, admin_ref, next_ticket_index, collection_address,
+        store_data(counters_ref, admin_transfer_ref, next_ticket_index, collection_address,
                    admin_address, price, ref_percent,
                    token_wallet_address, jp_amount, locked_jp_tokens,
                    token_balance, tl_usdt_amount, tl_usdt_until, tl_delay, tl_ton_amount, tl_ton_until);
@@ -581,7 +581,7 @@ int locked_jp_tokens,
 
         tl_ton_amount = 0;
         tl_ton_until  = 0;
-        store_data(counters_ref, admin_ref, next_ticket_index, collection_address,
+        store_data(counters_ref, admin_transfer_ref, next_ticket_index, collection_address,
                    admin_address, price, ref_percent,
                    token_wallet_address, jp_amount, locked_jp_tokens,
                    token_balance, tl_usdt_amount, tl_usdt_until, tl_delay, tl_ton_amount, tl_ton_until);
@@ -593,45 +593,17 @@ int locked_jp_tokens,
         throw_unless(401, equal_slices(sender_address, admin_address));
         slice new_admin = in_msg_body~load_msg_addr();
 
-        slice counters_slice = counters_ref.begin_parse();
-        int jp = counters_slice~load_uint(16);
-        int major = counters_slice~load_uint(16);
-        int high = counters_slice~load_uint(16);
-        int mid = counters_slice~load_uint(16);
-        int low_mid = counters_slice~load_uint(16);
-        int low = counters_slice~load_uint(16);
-        int mini = counters_slice~load_uint(16);
-
-        cell new_ref = begin_cell()
-            .store_uint(jp, 16)
-            .store_uint(major, 16)
-            .store_uint(high, 16)
-            .store_uint(mid, 16)
-            .store_uint(low_mid, 16)
-            .store_uint(low, 16)
-            .store_uint(mini, 16)
-            .end_cell();
-
-        admin_ref = begin_cell()
+        admin_transfer_ref = begin_cell()
             .store_slice(new_admin)
             .store_uint(now() + tl_delay, 64)
             .end_cell();
 
-        store_data(new_ref, admin_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, token_wallet_address, jp_amount, locked_jp_tokens, token_balance, tl_usdt_amount, tl_usdt_until, tl_delay, tl_ton_amount, tl_ton_until);
+        store_data(counters_ref, admin_transfer_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, token_wallet_address, jp_amount, locked_jp_tokens, token_balance, tl_usdt_amount, tl_usdt_until, tl_delay, tl_ton_amount, tl_ton_until);
         return();
     }
 
     if (op == OP_EXEC_ADMIN) {
-        slice counters_slice = counters_ref.begin_parse();
-        int jp = counters_slice~load_uint(16);
-        int major = counters_slice~load_uint(16);
-        int high = counters_slice~load_uint(16);
-        int mid = counters_slice~load_uint(16);
-        int low_mid = counters_slice~load_uint(16);
-        int low = counters_slice~load_uint(16);
-        int mini = counters_slice~load_uint(16);
-
-        slice admin_slice = admin_ref.begin_parse();
+        slice admin_slice = admin_transfer_ref.begin_parse();
         slice pending_admin = admin_slice~load_msg_addr();
         int pending_until = admin_slice~load_uint(64);
 
@@ -640,59 +612,31 @@ int locked_jp_tokens,
         ;; ensure new admin confirms transfer
         throw_unless(401, equal_slices(sender_address, pending_admin));
 
-        cell new_ref = begin_cell()
-            .store_uint(jp, 16)
-            .store_uint(major, 16)
-            .store_uint(high, 16)
-            .store_uint(mid, 16)
-            .store_uint(low_mid, 16)
-            .store_uint(low, 16)
-            .store_uint(mini, 16)
-            .end_cell();
-
-        admin_ref = begin_cell()
+        admin_transfer_ref = begin_cell()
             .store_slice(null_addr())
             .store_uint(0, 64)
             .end_cell();
 
-        store_data(new_ref, admin_ref, next_ticket_index, collection_address, pending_admin, price, ref_percent, token_wallet_address, jp_amount, locked_jp_tokens, token_balance, tl_usdt_amount, tl_usdt_until, tl_delay, tl_ton_amount, tl_ton_until);
+        store_data(counters_ref, admin_transfer_ref, next_ticket_index, collection_address, pending_admin, price, ref_percent, token_wallet_address, jp_amount, locked_jp_tokens, token_balance, tl_usdt_amount, tl_usdt_until, tl_delay, tl_ton_amount, tl_ton_until);
         return();
     }
 
     if (op == OP_CANCEL_ADMIN) {
         throw_unless(401, equal_slices(sender_address, admin_address));
 
-        slice counters_slice = counters_ref.begin_parse();
-        int jp = counters_slice~load_uint(16);
-        int major = counters_slice~load_uint(16);
-        int high = counters_slice~load_uint(16);
-        int mid = counters_slice~load_uint(16);
-        int low_mid = counters_slice~load_uint(16);
-        int low = counters_slice~load_uint(16);
-        int mini = counters_slice~load_uint(16);
-        cell new_ref = begin_cell()
-            .store_uint(jp, 16)
-            .store_uint(major, 16)
-            .store_uint(high, 16)
-            .store_uint(mid, 16)
-            .store_uint(low_mid, 16)
-            .store_uint(low, 16)
-            .store_uint(mini, 16)
-            .end_cell();
-
-        admin_ref = begin_cell()
+        admin_transfer_ref = begin_cell()
             .store_slice(null_addr())
             .store_uint(0, 64)
             .end_cell();
 
-        store_data(new_ref, admin_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, token_wallet_address, jp_amount, locked_jp_tokens, token_balance, tl_usdt_amount, tl_usdt_until, tl_delay, tl_ton_amount, tl_ton_until);
+        store_data(counters_ref, admin_transfer_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, token_wallet_address, jp_amount, locked_jp_tokens, token_balance, tl_usdt_amount, tl_usdt_until, tl_delay, tl_ton_amount, tl_ton_until);
         return();
     }
 
 
     if (op == 5) { ;; set token_wallet_address
     throw_unless(401, equal_slices(sender_address, admin_address));
-    store_data(counters_ref, admin_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, in_msg_body~load_msg_addr(), jp_amount, locked_jp_tokens, token_balance, tl_usdt_amount, tl_usdt_until, tl_delay, tl_ton_amount, tl_ton_until);
+    store_data(counters_ref, admin_transfer_ref, next_ticket_index, collection_address, admin_address, price, ref_percent, in_msg_body~load_msg_addr(), jp_amount, locked_jp_tokens, token_balance, tl_usdt_amount, tl_usdt_until, tl_delay, tl_ton_amount, tl_ton_until);
     return();
     }
 
@@ -726,7 +670,7 @@ int locked_jp_tokens,
 (cell, cell, int, slice, slice, int, int, slice, int, int, int, int, int, int, int, int) get_full_data() method_id {
     var (
         cell counters_ref,
-        cell admin_ref,
+        cell admin_transfer_ref,
         int next_ticket_index,
         slice collection_address,
         slice admin_address,
@@ -745,7 +689,7 @@ int locked_jp_tokens,
 
     return (
         counters_ref,
-        admin_ref,
+        admin_transfer_ref,
         next_ticket_index,
         collection_address,
         admin_address,

--- a/wrappers/Jet.ts
+++ b/wrappers/Jet.ts
@@ -42,7 +42,7 @@ export function jetConfigToCell(config: JetConfig): Cell {
         .storeUint(0, 16)
         .endCell();
 
-    const adminRef = beginCell()
+    const adminTransferRef = beginCell()
         .storeAddress(config.newAdminAddress ?? null)
         .storeUint(config.tlAdminUntil ?? 0n, 64)
         .endCell();
@@ -50,7 +50,7 @@ export function jetConfigToCell(config: JetConfig): Cell {
     return (
         beginCell()
             .storeRef(countersRef)
-            .storeRef(adminRef)
+            .storeRef(adminTransferRef)
             .storeUint(0, 64)
             .storeAddress(config.collectionAddress)
             .storeAddress(Address.parse(config.adminAddress))


### PR DESCRIPTION
## Summary
- keep pending admin transfer info in separate cell
- simplify admin transfer ops in jet.fc
- update Jet wrapper to match new layout

## Testing
- `npm install`
- `npm test`