### PR TITLE
Fix gas flow and increase min ticket value

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ for all other tiers stay the same. Win notifications are broadcast live via
 
 4. After the prize is issued, one of the counters `jp`, `major`, `high`, `mid`, `low_mid`, `low`, `mini` is increased. The NFT is minted from the collection and the jetton prize is sent to the player.
 5. The contract must always keep at least 0.05 TON and enough jettons for future payouts.
-6. When sending a ticket, store your TON wallet address first in `forward_payload`, followed by an optional referrer address. Set `forward_ton_amount` to at least `min_ticket_value` (≈0.27 TON).
+6. When sending a ticket, store your TON wallet address first in `forward_payload`, followed by an optional referrer address. Set `forward_ton_amount` to at least `min_ticket_value` (≈0.39 TON).
 
 ## Technology Stack
 - **FunC** for smart contracts

--- a/contracts/imports/functions.fc
+++ b/contracts/imports/functions.fc
@@ -112,7 +112,8 @@ slice token_wallet  ;; contract's Jetton wallet
     var jet_msg = begin_cell()
         .store_uint(flag::bounce(), 6)
         .store_slice(token_wallet)
-        .store_coins(1)
+        ;; Jetton wallet already has TON for gas
+        .store_coins(0)
         .store_uint(1, 1 + 4 + 4 + 64 + 32 + 1 + 1)
         .store_ref(jet_body)
         .end_cell();
@@ -134,14 +135,16 @@ slice token_wallet  ;; contract's Jetton wallet
         ;; excess gas and notifications back to initiator
         .store_slice(recipient)
         .store_maybe_ref(null())
-        .store_coins(1)
+        ;; enough TON for the player's wallet to process transfer
+        .store_coins(forward_fee())
         .store_uint(0, 1)
         .end_cell();
 
     var refund_msg = begin_cell()
         .store_uint(flag::bounce(), 6)
         .store_slice(token_wallet)
-        .store_coins(1)
+        ;; provide gas for Jetton wallet forwarding
+        .store_coins(outer_fee())
         .store_uint(1, 1 + 4 + 4 + 64 + 32 + 1 + 1)
         .store_ref(refund_body)
         .end_cell();

--- a/contracts/imports/params.fc
+++ b/contracts/imports/params.fc
@@ -13,5 +13,5 @@ int outer_fee() asm "150000000 PUSHINT";    ;; 0.15 TON
 ;; 0.05 TON пересылаем игроку вместе с jetton-transfer
 int forward_fee() asm "50000000 PUSHINT";   ;; 0.05 TON
 int transfer_fee() asm "70000000 PUSHINT"; ;; 0.05 TON (maybe 0.07 TON is too small)
-int min_ticket_value() asm "270000000 PUSHINT"; ;; minimal ton value to cover all transfers (~0.27 TON)
+int min_ticket_value() asm "390000000 PUSHINT"; ;; minimal ton value to cover worst case (~0.39 TON)
 

--- a/contracts/jet.fc
+++ b/contracts/jet.fc
@@ -211,7 +211,7 @@ int locked_jp_tokens,
 
         int excess = amount - price;
         if (excess > 0) {
-                var refund_transfer = begin_cell()
+            var refund_transfer = begin_cell()
                 .store_uint(op::jetton_transfer(), 32)
                 .store_uint(qid, 64)
                 .store_coins(excess)
@@ -219,14 +219,16 @@ int locked_jp_tokens,
                 ;; excess gas and notifications back to initiator
                 .store_slice(sender_wallet)
                 .store_maybe_ref(null())
-                .store_coins(1)
+                ;; provide gas for the player's wallet
+                .store_coins(forward_fee())
                 .store_uint(0, 1)
                 .end_cell();
 
             var refund_msg = begin_cell()
                 .store_uint(flag::bounce(), 6)
                 .store_slice(token_wallet_address)
-                .store_coins(1)
+                ;; supply Jetton wallet with forwarding gas
+                .store_coins(outer_fee())
                 ;; payload stored in a reference -> body_ref flag must be 1
                 .store_uint(1, 1 + 4 + 4 + 64 + 32 + 1 + 1)
                 .store_ref(refund_transfer)

--- a/helpers/index.ts
+++ b/helpers/index.ts
@@ -38,7 +38,7 @@ export class JetContract {
             sendInternalMessage: async (body: Cell) => {
                 await tokenWallet.send({
                     to: contract.address,
-                    value: toNano('0.27'),
+                    value: toNano('0.39'),
                     body,
                 });
             },
@@ -67,7 +67,7 @@ export class JetContract {
             ),
         );
 
-        await contract.sendDeploy(deployer.getSender(), toNano('0.27'));
+        await contract.sendDeploy(deployer.getSender(), toNano('0.39'));
         return new JetContract(blockchain, deployer, tokenWallet, contract, ticketPrice);
     }
 

--- a/scripts/depositUSDT.ts
+++ b/scripts/depositUSDT.ts
@@ -53,7 +53,7 @@ export async function run(provider: NetworkProvider) {
         .storeAddress(jetAddr)         // **dest = Jet contract (NOT its wallet)**
         .storeAddress(adminEOA)        // response_destination (any address)
         .storeUint(0, 1)               // no custom_payload
-        .storeCoins(toNano('0.27'))    // forward TON for Jet contract gas
+        .storeCoins(toNano('0.39'))    // forward TON for Jet contract gas
         .storeUint(1, 1)               // forward_payload is stored in **ref**
         .storeRef(fwdPayload)          // ref with 32-bit 'DEPO'
         .endCell();

--- a/tests/jet.transferNotification.spec.ts
+++ b/tests/jet.transferNotification.spec.ts
@@ -22,7 +22,7 @@ describe('jet.fc – sender validation', () => {
       amount: jet.ticketPrice,
       payload: jet.buildBuyPayload(),
     });
-    const result = await fake.send({ to: jet.contract.address, value: 270000000n, body: notif });
+    const result = await fake.send({ to: jet.contract.address, value: 390000000n, body: notif });
     expect(result.transactions).toHaveTransaction({ exitCode: 0 });
   });
 });

--- a/wrappers/Jet.spec.ts
+++ b/wrappers/Jet.spec.ts
@@ -29,7 +29,7 @@ describe('Jet', () => {
 
         await deployer.send({
             to: jet.address,
-            value: toNano('0.27'),
+            value: toNano('0.39'),
             body,
         });
     }
@@ -55,7 +55,7 @@ describe('Jet', () => {
             ),
         );
 
-        const deployResult = await jet.sendDeploy(deployer.getSender(), toNano('0.27'));
+        const deployResult = await jet.sendDeploy(deployer.getSender(), toNano('0.39'));
 
         expect(deployResult.transactions).toHaveTransaction({
             from: deployer.address,


### PR DESCRIPTION
## Summary
- update min_ticket_value to 0.39 TON
- ensure refunds provide enough gas
- stop attaching unnecessary TON in send_usdt
- update tests and scripts for new minimum

## Testing
- `npx jest`