### PR TITLE
Update jet jackpot logic and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,7 @@
 
 Lotshot is a decentralized lottery running entirely on the TON blockchain. The smart contracts are written in FunC and managed through a TypeScript tooling stack. Together they deploy an NFT collection and handle a lottery where prizes are paid out in jettons.
 
-The lottery accepts jetton payments for tickets. A random number determines which prize tier is won, and counters limit how many prizes of each level can be issued per round. When the Jackpot (10 000 USDT) is won, the lottery continues without pause.  
-The Jackpot line is removed, while all remaining prize tiers (Major → Try-Again) stay active  
-and new tickets remain fully valid for those rewards.
+The lottery accepts jetton payments for tickets. A random number determines which prize tier is won, and counters limit how many prizes of each level can be issued per round. After the jackpot (10 000 USDT) is won, the lottery continues without pause: no more jackpot payouts, but tickets can still be purchased and other prize levels remain active.
 
 ## Setup
 1. Run `npm install` to install the project dependencies.

--- a/contracts/jet.fc
+++ b/contracts/jet.fc
@@ -304,9 +304,7 @@ int locked_jp_tokens,
         int mini = counters_slice~load_uint(16);
         end_parse(counters_slice);
 
-        if (jp > 0) {
-            return ();
-        }
+
 
         if (x == 0) { ;; Jackpot 1/12000
             if (jp == 0) {
@@ -319,24 +317,24 @@ int locked_jp_tokens,
                 token_balance = token_balance - (jp_amount * jetton_decimals());
                 locked_jp_tokens = 0;      ;; reserve released
                 jp               = 1;      ;; jackpot claimed
-                next_ticket_index += 1;
-
-                ;; persist state
-                cell new_ref = begin_cell()
-                    .store_uint(jp, 16)
-                    .store_uint(major, 16)
-                    .store_uint(high, 16)
-                    .store_uint(mid, 16)
-                    .store_uint(low_mid, 16)
-                    .store_uint(low, 16)
-                    .store_uint(mini, 16)
-                    .end_cell();
-                store_data(new_ref, admin_transfer_ref, next_ticket_index, collection_address,
-                           admin_address, price, ref_percent,
-                           token_wallet_address, jp_amount, locked_jp_tokens,
-                           token_balance, tl_usdt_amount, tl_usdt_until, tl_delay, tl_ton_amount, tl_ton_until);
-                return ();
             }
+            next_ticket_index += 1;
+
+            ;; persist state
+            cell new_ref = begin_cell()
+                .store_uint(jp, 16)
+                .store_uint(major, 16)
+                .store_uint(high, 16)
+                .store_uint(mid, 16)
+                .store_uint(low_mid, 16)
+                .store_uint(low, 16)
+                .store_uint(mini, 16)
+                .end_cell();
+            store_data(new_ref, admin_transfer_ref, next_ticket_index, collection_address,
+                       admin_address, price, ref_percent,
+                       token_wallet_address, jp_amount, locked_jp_tokens,
+                       token_balance, tl_usdt_amount, tl_usdt_until, tl_delay, tl_ton_amount, tl_ton_until);
+            return ();
         }
 
         ;; Major: 3 prizes (x = 1..3)


### PR DESCRIPTION
## Summary
- allow continued ticket sales after the jackpot is won
- document that jackpot only pays out once while other prizes remain active

## Testing
- `npm install`
- `npm test`