### PR TITLE
Replace PUSHINT usages with const ints

### DIFF
--- a/contracts/collection.fc
+++ b/contracts/collection.fc
@@ -50,7 +50,7 @@ slice calculate_nft_item_address(int wc, cell state_init) {
 
 () deploy_nft_item(int item_index, cell nft_item_code, int amount, cell nft_content) impure {
   cell state_init = calculate_nft_item_state_init(item_index, nft_item_code);
-  slice nft_address = calculate_nft_item_address(workchain(), state_init);
+  slice nft_address = calculate_nft_item_address(workchain, state_init);
   var msg = begin_cell()
             .store_uint(0x18, 6)
             .store_slice(nft_address)

--- a/contracts/imports/functions.fc
+++ b/contracts/imports/functions.fc
@@ -24,11 +24,11 @@ cell generate_nft_content(int value, slice owner) {
 	var deploy_message = begin_cell()
 		.store_uint(0x18, 6)
 		.store_slice(collection_address)
-		.store_coins(transfer_fee())
+                .store_coins(transfer_fee)
 		.store_uint(0, 1 + 4 + 4 + 64 + 32 + 1 + 1)
                 .store_uint(1, 32)
                 .store_uint(query_id, 64)
-                .store_coins(mint_fee())
+                .store_coins(mint_fee)
 		.store_ref(content_cell)
 		.end_cell();
 

--- a/contracts/imports/params.fc
+++ b/contracts/imports/params.fc
@@ -1,6 +1,6 @@
-int workchain()       asm "0 PUSHINT";
+const int workchain = 0;
 
 ;;--- fees and deposits ---
 
-int transfer_fee()  asm "30000000 PUSHINT";  ;; 0.03 TON — value Jet → Collection
-int mint_fee()      asm "25000000 PUSHINT";  ;; 0.025 TON — value used inside deploy-NFT
+const int transfer_fee = 30000000;  ;; 0.03 TON — value Jet → Collection
+const int mint_fee = 25000000;      ;; 0.025 TON — value used inside deploy-NFT


### PR DESCRIPTION
## Summary
- declare numeric constants instead of using `PUSHINT`
- adjust call sites to use new constants

## Testing
- `npm install`
- `npm test`