### PR TITLE
Replace PUSHINT opcodes with inline constants

### DIFF
--- a/contracts/imports/op-codes.fc
+++ b/contracts/imports/op-codes.fc
@@ -1,10 +1,10 @@
 ;;int op::transfer() asm "0x5fcc3d14 PUSHINT";
 ;; Jetton (FT) transfer по TEP-74
-int op::jetton_transfer() asm "0x0f8a7ea5 PUSHINT";
-int op::jetton_transfer_notification() asm "0x7362d09c PUSHINT";
-int op::get_royalty_params() asm "0x693d3950 PUSHINT";
-int op::report_royalty_params() asm "0xa8cb00ad PUSHINT";
-int op::send_prize() asm "0x5052495a PUSHINT"; ;; 'PRIZ'
-int op::send_reff() asm "0x52454646 PUSHINT"; ;; 'REFF'
-int op::send_usdt() asm "0x55534454 PUSHINT"; ;; 'USDT'
-int op::admin_deposit() asm "0x4445504f PUSHINT"; ;; 'DEPO'
+int op::jetton_transfer() inline { return 0x0f8a7ea5; }
+int op::jetton_transfer_notification() inline { return 0x7362d09c; }
+int op::get_royalty_params() inline { return 0x693d3950; }
+int op::report_royalty_params() inline { return 0xa8cb00ad; }
+int op::send_prize() inline { return 0x5052495a; } ;; 'PRIZ'
+int op::send_reff() inline { return 0x52454646; } ;; 'REFF'
+int op::send_usdt() inline { return 0x55534454; } ;; 'USDT'
+int op::admin_deposit() inline { return 0x4445504f; } ;; 'DEPO'

--- a/contracts/imports/params.fc
+++ b/contracts/imports/params.fc
@@ -1,17 +1,17 @@
 
-int workchain() asm "0 PUSHINT";
+int workchain() inline { return 0; }
 
 slice null_addr() asm "b{00} PUSHSLICE";
-int flag::regular() asm "0x10 PUSHINT";
-int flag::bounce() asm "0x18 PUSHINT";   ;; internal + bounce, IHR-off
-int mint_fee() asm "50000000 PUSHINT"; ;; 0.15 TON is too large, try set 0.05 TON
-int storage_coins() asm "20000000 PUSHINT"; ;; 0.02 TON
-int player_fee() asm "50000000 PUSHINT"; ;; 0.05 TON
-int jetton_decimals() asm "1000000 PUSHINT"; ;; jetton has 6 decimal places
+int flag::regular() inline { return 0x10; }
+int flag::bounce() inline { return 0x18; }   ;; internal + bounce, IHR-off
+int mint_fee() inline { return 50000000; } ;; 0.15 TON is too large, try set 0.05 TON
+int storage_coins() inline { return 20000000; } ;; 0.02 TON
+int player_fee() inline { return 50000000; } ;; 0.05 TON
+int jetton_decimals() inline { return 1000000; } ;; jetton has 6 decimal places
 ;; 0.15 TON кладём в сообщение для оплаты всех расходов
-int outer_fee() asm "150000000 PUSHINT";    ;; 0.15 TON
+int outer_fee() inline { return 150000000; }    ;; 0.15 TON
 ;; 0.05 TON пересылаем игроку вместе с jetton-transfer
-int forward_fee() asm "50000000 PUSHINT";   ;; 0.05 TON
-int transfer_fee() asm "70000000 PUSHINT"; ;; 0.05 TON (maybe 0.07 TON is too small)
-int min_ticket_value() asm "390000000 PUSHINT"; ;; minimal ton value to cover worst case (~0.39 TON)
+int forward_fee() inline { return 50000000; }   ;; 0.05 TON
+int transfer_fee() inline { return 70000000; } ;; 0.05 TON (maybe 0.07 TON is too small)
+int min_ticket_value() inline { return 390000000; } ;; minimal ton value to cover worst case (~0.39 TON)
 

--- a/contracts/jet.fc
+++ b/contracts/jet.fc
@@ -4,13 +4,13 @@
 ;; Jackpot is paid automatically; no admin trigger exists.
 ;; USDT and TON withdrawals use timelock (op 6/7 & 11/12).
 
-int JACKPOT_PRIZE() asm "10000 PUSHINT"; ;; 10,000 tokens
-int MAJOR_PRIZE() asm "1800 PUSHINT";    ;; 1,800 tokens
-int HIGH_PRIZE() asm "700 PUSHINT";      ;; 700 tokens
-int MID_PRIZE() asm "180 PUSHINT";       ;; 180 tokens
-int LOW_MID_PRIZE() asm "50 PUSHINT";    ;; 50 tokens
-int LOW_PRIZE() asm "25 PUSHINT";        ;; 25 tokens
-int MINI_PRIZE() asm "10 PUSHINT";       ;; 10 tokens
+int JACKPOT_PRIZE() inline { return 10000; } ;; 10,000 tokens
+int MAJOR_PRIZE() inline { return 1800; }    ;; 1,800 tokens
+int HIGH_PRIZE() inline { return 700; }      ;; 700 tokens
+int MID_PRIZE() inline { return 180; }       ;; 180 tokens
+int LOW_MID_PRIZE() inline { return 50; }    ;; 50 tokens
+int LOW_PRIZE() inline { return 25; }        ;; 25 tokens
+int MINI_PRIZE() inline { return 10; }       ;; 10 tokens
 
 const int OP_SCHEDULE_USDT = 6;
 const int OP_EXEC_USDT     = 7;


### PR DESCRIPTION
## Summary
- use inline functions instead of `asm "PUSHINT"` for opcode and parameter constants

## Testing
- `npm install`
- `npm test --silent`