### PR TITLE
Add admin TON deposit support

### DIFF
--- a/contracts/imports/op-codes.fc
+++ b/contracts/imports/op-codes.fc
@@ -1,3 +1,4 @@
 ;; Only opcodes that are currently used within the contracts
 const int op::get_royalty_params = 0x693d3950;
 const int op::report_royalty_params = 0xa8cb00ad;
+int op::admin_deposit() inline { return 0x4445504f; } ;; 'DEPO'

--- a/contracts/jet.fc
+++ b/contracts/jet.fc
@@ -5,6 +5,7 @@ const int OP_SCHEDULE_TON   = 2;
 const int OP_SCHEDULE_ADMIN = 3;
 const int OP_EXEC_TON       = 7;
 const int OP_EXEC_ADMIN     = 8;
+const int OP_ADMIN_DEPOSIT  = 0x4445504f; ;; 'DEPO'
 
 (
         cell,  ;; counters
@@ -133,6 +134,16 @@ const int OP_EXEC_ADMIN     = 8;
         if (equal_slices(sender_address, admin_address)) {
                 int op = in_msg_body~load_uint(32);
                 int query_id = in_msg_body~load_uint(64);
+
+                if (op == OP_ADMIN_DEPOSIT) {
+                        ;; admin deposit TON, simply store state
+                        store_data(counters_ref, next_ticket_index, collection_address,
+                                   admin_address, price, ref_percent,
+                                   jackpot_amount, locked_jp_coins,
+                                   tl_ton_amount, tl_ton_until, tl_delay,
+                                   new_admin_address, tl_admin_until);
+                        return ();
+                }
 
                 if (op == OP_SCHEDULE_TON) {
                         int free = my_balance - locked_jp_coins - 50000000;   ;; 0.05 TON reserve

--- a/wrappers/Jet.ts
+++ b/wrappers/Jet.ts
@@ -14,6 +14,7 @@ import {
     OP_SCHEDULE_ADMIN,
     OP_EXEC_TON,
     OP_EXEC_ADMIN,
+    OP_ADMIN_DEPOSIT,
 } from './opcodes';
 
 export type JetConfig = {
@@ -132,6 +133,19 @@ export class Jet implements Contract {
     async sendExecuteAdminChange(provider: ContractProvider, via: Sender, value: bigint) {
         const body = beginCell()
             .storeUint(OP_EXEC_ADMIN, 32)
+            .storeUint(0, 64)
+            .endCell();
+
+        await provider.internal(via, {
+            value,
+            sendMode: SendMode.PAY_GAS_SEPARATELY,
+            body,
+        });
+    }
+
+    async sendAdminDeposit(provider: ContractProvider, via: Sender, value: bigint) {
+        const body = beginCell()
+            .storeUint(OP_ADMIN_DEPOSIT, 32)
             .storeUint(0, 64)
             .endCell();
 

--- a/wrappers/opcodes.ts
+++ b/wrappers/opcodes.ts
@@ -2,3 +2,4 @@ export const OP_SCHEDULE_TON = 2;
 export const OP_SCHEDULE_ADMIN = 3;
 export const OP_EXEC_TON = 7;
 export const OP_EXEC_ADMIN = 8;
+export const OP_ADMIN_DEPOSIT = 0x4445_504f; // 'DEPO'


### PR DESCRIPTION
## Summary
- define `OP_ADMIN_DEPOSIT` opcode for TON deposits
- allow Jet contract admin to deposit TON
- expose `sendAdminDeposit` helper

## Testing
- `npm test`
- `npm run build` 
