### PR TITLE
Fix Jet tuple size and add USDT jackpot env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,9 @@ REF_PERCENT=10 # referral payout in basis points
 # Jackpot size for TON lottery (whole TON, NOT nanoTON).
 # Default: 1000 on mainnet, 10 on testnet.
 JACKPOT_AMOUNT_TON=1000
+# Jackpot size for USDT lottery (whole USDT, NOT nano tokens).
+# Default: 100 on mainnet, 1 on testnet.
+JACKPOT_AMOUNT_USDT=100
 # Timelock delay for TON withdrawals (seconds)
 # default: 172800 on mainnet, 3600 on testnet
 TIMELOCK_DELAY_SEC_TON=172800

--- a/README.md
+++ b/README.md
@@ -53,7 +53,9 @@ The `.env` file requires the following fields:
 - `REF_PERCENT` – referral fee in basis points.  
 - `JACKPOT_AMOUNT_TON` – jackpot size in whole TON for the TON lottery
   (defaults to 1000 TON on mainnet and 10 TON on testnet if unset).
-- `TIMELOCK_DELAY_SEC_TON` – timelock delay (in seconds) for TON withdrawals  
+- `JACKPOT_AMOUNT_USDT` – jackpot size in whole USDT for the USDT lottery
+  (defaults to 100 USDT on mainnet and 1 USDT on testnet if unset).
+- `TIMELOCK_DELAY_SEC_TON` – timelock delay (in seconds) for TON withdrawals
   (defaults: 172 800 s on mainnet, 3 600 s on testnet).
 
 ## Compiling contracts

--- a/contracts/jet.fc
+++ b/contracts/jet.fc
@@ -404,7 +404,7 @@ const int OP_ADMIN_DEPOSIT  = 0x4445504f; ;; 'DEPO'
 }
 
 (int, int, int, int, int, int, int) get_counters() method_id {
-        (cell counters_ref, _, _, _, _, _, _, _, _, _, _, _, _) = load_data();
+        (cell counters_ref, _, _, _, _, _, _, _, _, _, _, _, _, _) = load_data();
 
 	slice counters_slice = counters_ref.begin_parse();
 		int jp = counters_slice~load_uint(16);


### PR DESCRIPTION
## Summary
- fix `get_counters` tuple length in `jet.fc`
- document `JACKPOT_AMOUNT_USDT` env variable
- add example value in `.env.example`

## Testing
- `npm test`